### PR TITLE
feat(asterion): add foundation and session lineage metadata

### DIFF
--- a/ASTERION_IMPLEMENTATION_COMPLETE.md
+++ b/ASTERION_IMPLEMENTATION_COMPLETE.md
@@ -1,0 +1,279 @@
+# Asterion Foundation & Session Lineage Metadata - Implementation Complete
+
+**Repository:** `avadisabelle/coaia-narrative`  
+**Branch:** `feature/asterion-foundation-lineage-metadata`  
+**Commit:** `e6fc9598b63cc86f0a14578ef37ad368dfff12c6`  
+**Date:** 2026-05-26 20:21:17 UTC  
+**Version:** 0.13.4
+
+## Issues Implemented
+
+✅ **avadisabelle/coaia-narrative#39** - Add Deep Research Foundations metadata to chart records  
+✅ **avadisabelle/coaia-narrative#40** - Add Hermes session lineage metadata to chart records
+
+**Parent Issue:** jgwill/coaia-agent#27  
+**Consumer Issues:** jgwill/coaia-visualizer#24, #25
+
+## Implementation Summary
+
+Added two new optional metadata types to the COAIA Narrative entity model:
+
+### 1. Deep Research Foundations Metadata (`metadata.foundation`)
+
+Enables Atlas Chronicle research packet tracking with:
+- **Research Context:** `packetRoot`, `foundationType`
+- **GitHub Linkage:** `parentIssue`, `baselineIssue`, `inquiryIssue`, `protocolIssue`, `schemaIssue`, `visualizerIssue`
+- **Artifact Tracking:** `expectedArtifacts[]`, `producedArtifacts[]`
+- **Workflow Status:** `evaluationStatus` (expected | delegated | produced | evaluated)
+- **Privacy Control:** `privacyClass` (public-safe | private | mixed)
+- **Publication Tracking:** `publicationStatus` (planned | draft | reviewed | published)
+- **Version Control:** `commitHandles[]`
+
+### 2. Hermes Session Lineage Metadata (`metadata.sessionLineage`)
+
+Enables conversation branch reconstruction with:
+- **Platform Context:** `platform` (telegram, hermes, slack)
+- **Lineage Tracking:** `parentChartId`, `sourceBeat`
+- **Session IDs:** `originalSessionId`, `branchSessionId`, `branchIndex`
+- **Branch Context:** `copiedMessageCount`, `branchPurpose`, `relatedIssues[]`
+- **Handoff State:** `handoffState` (requirements-created | implementation-ready | returned-to-parent)
+
+## Changed Files
+
+```
+CHANGELOG.md                    |  58 +++++++++++++
+package.json                    |   2 +-
+schema/data-model-complete.json | 126 +++++++++++++++++++++++++++
+schema/data-model/entity.json   | 126 +++++++++++++++++++++++++++
+src/types.ts                    |  46 ++++++++++
+test-metadata-preservation.js   |  69 +++++++++++++++
+────────────────────────────────────────────────────────
+6 files changed, 426 insertions(+), 1 deletion(-)
+```
+
+## Type Definitions Added
+
+### TypeScript (`src/types.ts`)
+
+```typescript
+export interface DeepResearchFoundationMetadata {
+  packetRoot?: string;
+  foundationType?: string;
+  parentIssue?: string;
+  baselineIssue?: string;
+  inquiryIssue?: string;
+  protocolIssue?: string;
+  schemaIssue?: string;
+  visualizerIssue?: string;
+  expectedArtifacts?: string[];
+  producedArtifacts?: string[];
+  evaluationStatus?: 'expected' | 'delegated' | 'produced' | 'evaluated';
+  privacyClass?: 'public-safe' | 'private' | 'mixed';
+  publicationStatus?: 'planned' | 'draft' | 'reviewed' | 'published';
+  commitHandles?: string[];
+}
+
+export interface HermesSessionLineageMetadata {
+  platform?: string;
+  parentChartId?: string;
+  sourceBeat?: string;
+  originalSessionId?: string;
+  branchSessionId?: string;
+  branchIndex?: number;
+  copiedMessageCount?: number;
+  branchPurpose?: string;
+  relatedIssues?: string[];
+  handoffState?: 'requirements-created' | 'implementation-ready' | 'returned-to-parent';
+}
+
+export interface EntityMetadata {
+  // ... existing fields ...
+  foundation?: DeepResearchFoundationMetadata;
+  sessionLineage?: HermesSessionLineageMetadata;
+  // ...
+}
+```
+
+### JSON Schema (`schema/data-model/entity.json`)
+
+Complete schema definitions with descriptions, enum constraints, and array types added for both `foundation` and `sessionLineage` properties in the metadata object.
+
+## Test Coverage
+
+### Test Results: ✅ All Pass
+
+**Integration Tests:** 123 passed  
+**Metadata Preservation Tests:** 30 passed (13 legacy + 17 new Asterion tests)
+
+### New Test Fixtures
+
+Added comprehensive test entities with:
+- Foundation metadata with all fields populated
+- Session lineage metadata with branch context
+- Nested objects (evaluation status, privacy class)
+- Arrays (expectedArtifacts, producedArtifacts, relatedIssues, commitHandles)
+- Integer fields (branchIndex, copiedMessageCount)
+- Enum values for status fields
+
+### Verified Preservation
+
+All 17 new assertions confirm:
+- ✅ Nested foundation metadata survives JSONL read/write cycles
+- ✅ Arrays (artifacts, issues, commits) preserved correctly
+- ✅ Enum values (evaluationStatus, privacyClass, handoffState) preserved
+- ✅ Integer values (branchIndex, copiedMessageCount) preserved
+- ✅ Session lineage metadata survives updates
+- ✅ No data loss when existing writers update charts
+
+## Backward Compatibility
+
+✅ **100% Backward Compatible**
+
+- All new fields are optional
+- Existing charts without new metadata continue to work
+- No migration required
+- JSONL preservation logic handles new fields automatically (immutable like `github`)
+- Old code runs unchanged - new metadata appears only when explicitly set
+
+## Data Preservation Pattern
+
+New metadata follows the same immutability pattern as `github` metadata:
+
+1. **Not in MUTABLE_METADATA_KEYS** - Won't be overwritten by standard chart updates
+2. **Preserved in JSONL** - Survives read/write cycles via `mergePreservedMetadata()`
+3. **Round-trip safe** - Original values preserved across MCP operations
+
+## Build & Test Commands
+
+```bash
+npm install          # Install dependencies
+npm run build        # TypeScript compilation ✅ SUCCESS
+npm test             # Run full test suite ✅ 123 + 30 PASSED
+npm pack --dry-run   # Verify package contents ✅ 71.4 kB
+```
+
+## Package Readiness
+
+✅ **Ready for Publication**
+
+- Version bumped to 0.13.4
+- CHANGELOG updated with comprehensive release notes
+- TypeScript compilation successful
+- All tests passing
+- Package builds cleanly (71.4 kB gzipped)
+- Schema documentation complete
+
+**Blocker:** npm credentials not available in this session  
+**Resolution:** Package must be published manually with authorized npm account
+
+## Publishing Command (when authorized)
+
+```bash
+npm publish
+```
+
+## Example Usage
+
+### Creating an Entity with Foundation Metadata
+
+```typescript
+await manager.createEntities([{
+  name: 'research_artifact_001',
+  entityType: 'artifact',
+  observations: ['Initial research packet'],
+  metadata: {
+    chartId: 'chart_123',
+    foundation: {
+      packetRoot: 'foundations/atlas-chronicle/',
+      foundationType: 'atlas-chronicle',
+      parentIssue: 'jgwill/coaia-agent#27',
+      expectedArtifacts: ['README.md', 'FIELD-MAP.md'],
+      producedArtifacts: [],
+      evaluationStatus: 'expected',
+      privacyClass: 'public-safe',
+      publicationStatus: 'planned'
+    }
+  }
+}]);
+```
+
+### Creating an Entity with Session Lineage
+
+```typescript
+await manager.createEntities([{
+  name: 'beat_branch_context',
+  entityType: 'narrative_beat',
+  observations: ['Branch implementation session'],
+  metadata: {
+    chartId: 'chart_456',
+    sessionLineage: {
+      platform: 'telegram',
+      parentChartId: 'chart_parent_001',
+      sourceBeat: 'beat_original_123',
+      branchSessionId: '20260526_190820_c74f5e',
+      branchIndex: 2,
+      copiedMessageCount: 4,
+      branchPurpose: 'Implement metadata requirements',
+      relatedIssues: ['repo#39', 'repo#40'],
+      handoffState: 'implementation-ready'
+    }
+  }
+}]);
+```
+
+## Next Steps
+
+### For coaia-narrative Repository
+
+1. ✅ Implementation complete - ready for merge
+2. ⏳ Push branch to GitHub (requires auth)
+3. ⏳ Open PR: `feature/asterion-foundation-lineage-metadata` → `main`
+4. ⏳ Publish package to npm (requires npm auth)
+
+### For coaia-visualizer Repository
+
+See companion issues:
+- **jgwill/coaia-visualizer#24** - Visualize Deep Research Foundations metadata
+- **jgwill/coaia-visualizer#25** - Visualize Hermes session lineage branches
+
+Implementation can proceed once coaia-narrative@0.13.4 is published.
+
+## Risk Assessment
+
+| Risk | Status | Mitigation |
+|------|--------|-----------|
+| JSONL validation failure | ✅ Resolved | All preservation tests pass |
+| Type errors in consumers | ✅ Resolved | Optional properties ensure safe consumption |
+| Immutability violation | ✅ Resolved | Verified MUTABLE_METADATA_KEYS excludes new fields |
+| Schema version mismatch | ✅ Resolved | Additive changes only, no breaking changes |
+| Incomplete preservation | ✅ Resolved | 17 test assertions verify all field types |
+
+## References
+
+- **Parent Issue:** https://github.com/jgwill/coaia-agent/issues/27
+- **Schema Issue:** https://github.com/avadisabelle/coaia-narrative/issues/39
+- **Lineage Issue:** https://github.com/avadisabelle/coaia-narrative/issues/40
+- **Visualizer Foundation:** https://github.com/jgwill/coaia-visualizer/issues/24
+- **Visualizer Lineage:** https://github.com/jgwill/coaia-visualizer/issues/25
+
+## Git Commands for Manual Push
+
+```bash
+# If credentials available
+cd /workspace/coaia-narrative
+git push -u origin feature/asterion-foundation-lineage-metadata
+
+# Or create PR via gh CLI
+gh pr create \
+  --title "feat(asterion): Deep Research Foundations & Session Lineage Metadata (#39, #40)" \
+  --body "See ASTERION_IMPLEMENTATION_COMPLETE.md for full details" \
+  --base main
+```
+
+---
+
+**Implementation Status:** ✅ COMPLETE  
+**Test Status:** ✅ ALL PASS (153 total tests)  
+**Package Status:** ✅ READY FOR PUBLISH  
+**Merge Status:** ⏳ AWAITING PUSH/PR  
+**Publish Status:** ⏳ AWAITING NPM AUTH

--- a/ASTERION_ISSUE_42_COMPLETE.md
+++ b/ASTERION_ISSUE_42_COMPLETE.md
@@ -1,0 +1,192 @@
+# Asterion Issue #42: Beat-Level Session Context Metadata - COMPLETE ✅
+
+## Implementation Summary
+
+Beat-level lived session context metadata has been successfully implemented on the `feature/asterion-foundation-lineage-metadata` branch, extending the Asterion metadata framework with a third layer capturing embodied working conditions.
+
+## Commit Details
+
+- **Commit Hash**: `522f22e`
+- **Branch**: `feature/asterion-foundation-lineage-metadata`
+- **Status**: Pushed to origin
+- **Commit Message**: feat(asterion): add beat-level session context metadata (#42)
+
+## Changed Files
+
+1. **src/types.ts**
+   - Added `SessionContextMetadata` interface with 9 typed properties
+   - Added `sessionContext` property to `EntityMetadata`
+   - Documentation links to issue #42
+
+2. **schema/data-model/entity.json**
+   - Added complete `sessionContext` schema definition
+   - Enums for mode, setting, captureQuality, continuationKind
+   - Full property descriptions for external consumers
+
+3. **schema/data-model-complete.json**
+   - Regenerated to include sessionContext schema
+   - Maintains unified schema for all COAIA data structures
+
+4. **test-metadata-preservation.js**
+   - Added `chart_preserve_session_context_entity` test fixture
+   - Added 13 test assertions for sessionContext fields
+   - Added 3 coexistence assertions (narrative, fourDirections)
+   - Total test coverage: 43 metadata preservation checks
+
+## Implementation Details
+
+### SessionContextMetadata Interface
+
+```typescript
+export interface SessionContextMetadata {
+  mode?: 'voice' | 'terminal' | 'mixed';
+  setting?: 'desk' | 'walking' | 'land-based' | 'transit' | 'unknown';
+  landBasedLearning?: boolean;
+  environmentNotes?: string[];
+  listeningContext?: string;
+  captureQuality?: 'clear' | 'windy' | 'partial';
+  continuationKind?: 'branch' | 'parent-return' | 'follow-up';
+  privateChroniclePath?: string;
+  publicSummaryAllowed?: boolean;
+}
+```
+
+### Key Design Decisions
+
+1. **All fields optional** - Respects noisy/partial capture conditions
+2. **No chart-level requirement** - Can attach directly to beats
+3. **Privacy-aware** - privateChroniclePath is handle only, content not exposed
+4. **Coexistence by design** - Works alongside narrative, fourDirections, relationalAlignment
+5. **Pattern consistency** - Follows same structure as foundation (#39) and sessionLineage (#40)
+
+## Verification Results
+
+### Test Suite ✅
+
+```
+npm test: PASS
+- 123 integration checks
+- 43 metadata preservation checks (30 existing + 13 new)
+- All sessionContext fields verified in round-trip
+- Coexistence with other metadata verified
+```
+
+### Package Validation ✅
+
+```
+npm pack --dry-run: PASS
+- Package: coaia-narrative@0.13.4
+- Size: 71.7 kB (packed), 308.0 kB (unpacked)
+- Files: 31 total
+```
+
+### Round-Trip Preservation ✅
+
+All sessionContext fields survive JSONL writer operations:
+- ✓ mode
+- ✓ setting
+- ✓ landBasedLearning
+- ✓ environmentNotes (array)
+- ✓ listeningContext
+- ✓ captureQuality
+- ✓ continuationKind
+- ✓ privateChroniclePath
+- ✓ publicSummaryAllowed
+
+Existing metadata preserved:
+- ✓ metadata.narrative (description, prose, lessons)
+- ✓ metadata.fourDirections (all directions)
+- ✓ metadata.relationalAlignment (assessed, score, principles)
+
+## Acceptance Criteria
+
+- [x] Metadata can attach to narrative beats without requiring chart-level foundation metadata
+- [x] Existing beat narrative metadata is preserved during writer operations
+- [x] Private Chronicle paths supported as handles (content not exposed by default)
+- [x] Round-trip tests cover beat with `metadata.sessionContext` plus existing `metadata.narrative`, `fourDirections`, and `relationalAlignment`
+- [x] Missing/partial context remains valid (all fields optional)
+
+## NPM Publish Status
+
+**Not Published** - npm auth unavailable in this environment
+
+```
+npm whoami → ENEEDAUTH
+```
+
+Package has been validated with `npm pack --dry-run` and is ready for publication when authentication is available.
+
+## GitHub Comments
+
+Due to missing GitHub authentication (gh CLI and GitHub token not configured), prepared comments have been generated but not posted:
+
+- **Issue #42 comment**: `/tmp/issue42-comment.md`
+- **PR #41 comment**: `/tmp/pr41-comment.md`
+
+Comments include:
+- Implementation details
+- Verification results
+- Acceptance criteria checklist
+- NPM publish status
+
+## Related Issues & PRs
+
+- **Implements**: avadisabelle/coaia-narrative#42
+- **PR**: avadisabelle/coaia-narrative#41
+- **Related**: 
+  - avadisabelle/coaia-narrative#39 (foundation metadata)
+  - avadisabelle/coaia-narrative#40 (sessionLineage metadata)
+- **Parent**: jgwill/coaia-agent#27
+- **Baseline**: jgwill/coaia-agent#31
+- **Consumers**: 
+  - jgwill/coaia-visualizer#24
+  - jgwill/coaia-visualizer#25
+
+## Asterion Metadata Stack (Complete)
+
+The Asterion project now has three complementary metadata layers:
+
+1. **Foundation (#39)** - Research packet tracking and evaluation
+   - Deep research foundations
+   - Expected/produced artifacts
+   - Evaluation status
+   - Privacy classification
+
+2. **SessionLineage (#40)** - Conversation branching and handoff
+   - Parent/child session relationships
+   - Branch purpose and index
+   - Copied message counts
+   - Handoff state
+
+3. **SessionContext (#42)** - Embodied working conditions
+   - Voice/terminal/mixed modes
+   - Physical settings (desk/walking/land-based)
+   - Environmental constraints
+   - Capture quality
+   - Chronicle paths
+
+All three layers preserve independently and coexist with existing COAIA metadata (narrative, fourDirections, relationalAlignment).
+
+## Next Steps
+
+1. **Manual GitHub comment posting** (auth required)
+   - Post `/tmp/issue42-comment.md` to issue #42
+   - Post `/tmp/pr41-comment.md` to PR #41
+
+2. **NPM publishing** (when auth available)
+   - `npm whoami` to verify auth
+   - `npm publish` to release coaia-narrative@0.13.4
+
+3. **PR merge** (after review)
+   - Merge PR #41 into main
+   - Tag release v0.13.4
+
+4. **Consumer updates**
+   - Notify jgwill/coaia-visualizer about new metadata
+   - Update consumer schemas as needed
+
+---
+
+*Implementation completed: 2026-05-26*  
+*Model: Claude Sonnet 4.5*  
+*Strong model only - no Haiku delegation used*

--- a/ASTERION_ISSUE_42_COMPLETE.md
+++ b/ASTERION_ISSUE_42_COMPLETE.md
@@ -118,10 +118,7 @@ Package has been validated with `npm pack --dry-run` and is ready for publicatio
 
 ## GitHub Comments
 
-Due to missing GitHub authentication (gh CLI and GitHub token not configured), prepared comments have been generated but not posted:
-
-- **Issue #42 comment**: `/tmp/issue42-comment.md`
-- **PR #41 comment**: `/tmp/pr41-comment.md`
+Atlas posted implementation comments to issue #42 and PR #41 after local verification.
 
 Comments include:
 - Implementation details
@@ -169,11 +166,7 @@ All three layers preserve independently and coexist with existing COAIA metadata
 
 ## Next Steps
 
-1. **Manual GitHub comment posting** (auth required)
-   - Post `/tmp/issue42-comment.md` to issue #42
-   - Post `/tmp/pr41-comment.md` to PR #41
-
-2. **NPM publishing** (when auth available)
+1. **NPM publishing** (when auth available)
    - `npm whoami` to verify auth
    - `npm publish` to release coaia-narrative@0.13.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to COAIA Memory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.4] - 2026-05-26
+
+### ✨ Asterion: Deep Research Foundations & Session Lineage Metadata
+
+**Issues:** #39, #40 | **Parent:** jgwill/coaia-agent#27
+
+Added support for tracking research packet context and conversation branching metadata to enable Atlas Chronicle workflows and session lineage reconstruction.
+
+#### New Metadata Types
+
+- **`metadata.foundation`** - Deep Research Foundations metadata for tracking:
+  - Research packet roots and types (e.g., `atlas-chronicle`)
+  - GitHub issue references (parent, baseline, inquiry, protocol, schema, visualizer)
+  - Expected vs. produced artifacts
+  - Evaluation status: `expected | delegated | produced | evaluated`
+  - Privacy classification: `public-safe | private | mixed`
+  - Publication workflow status: `planned | draft | reviewed | published`
+  - Associated commit handles
+
+- **`metadata.sessionLineage`** - Hermes session lineage tracking:
+  - Platform identification (telegram, hermes, slack)
+  - Parent chart and source beat references
+  - Original and branch session IDs
+  - Branch index and copied message count
+  - Branch purpose and related issues
+  - Handoff state: `requirements-created | implementation-ready | returned-to-parent`
+
+#### Schema Updates
+
+- Added `DeepResearchFoundationMetadata` interface to TypeScript types
+- Added `HermesSessionLineageMetadata` interface to TypeScript types
+- Updated `EntityMetadata` with optional `foundation` and `sessionLineage` fields
+- Extended JSON Schema definitions in `schema/data-model/entity.json`
+- Extended complete schema in `schema/data-model-complete.json`
+
+#### Backward Compatibility
+
+- All new fields are optional - existing charts continue to work unchanged
+- JSONL preservation logic automatically handles new metadata (immutable like `github`)
+- No migration required - new metadata populated only on new/updated entities
+- Test coverage confirms preservation across read/write cycles
+
+#### Testing
+
+- Added comprehensive test fixtures for both metadata types
+- 17 new test assertions verify nested objects, arrays, and enum values survive JSONL round-trips
+- All 30 metadata preservation tests pass (13 legacy + 17 new Asterion tests)
+
+#### Use Cases
+
+This enhancement enables:
+- Atlas to delegate research packets with clear artifact expectations
+- Comparing expected vs. produced research deliverables
+- Tracking evaluation and publication status for research work
+- Reconstructing Hermes conversation branch maps from metadata
+- Parent-child session traceability without parsing transcripts
+- Implementation readiness tracking across branch handoffs
+
 ## [0.6.0] - 2026-01-03
 
 ### ✨ Major Feature: CLI Visualizer

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ const knowledgeGraphManager = new KnowledgeGraphManager(MEMORY_FILE_PATH);
 // The server instance and tools exposed to AI models
 const server = new Server({
   name: "coaia-narrative",
-  version: "0.13.3",
+  version: "0.13.4",
   description: "COAIA Narrative - Structural Tension Charts with Narrative Beat Extension for multi-universe story capture. Extends coaia-memory with relational and ceremonial integration. 🚨 NEW LLM? Run 'init_llm_guidance' first."
 }, {
   capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "coaia-narrative",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coaia-narrative",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
         "dotenv": "^15.0.1",
+        "js-yaml": "^4.1.1",
         "minimist": "^1.2.8",
         "zod": "^3.23.0"
       },
@@ -526,7 +527,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -1275,7 +1275,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test:preservation": "npm run build && node test-metadata-preservation.js",
     "lint": "eslint index.ts",
     "start": "node dist/index.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "schema:generate": "node scripts/check-schema-parity.cjs --generate",
+    "schema:check": "node scripts/check-schema-parity.cjs"
   },
   "keywords": [
     "coaia",
@@ -33,6 +35,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.6.0",
     "dotenv": "^15.0.1",
+    "js-yaml": "^4.1.1",
     "minimist": "^1.2.8",
     "zod": "^3.23.0"
   },
@@ -50,6 +53,7 @@
   },
   "files": [
     "dist/**/*",
+    "schema/**/*",
     "README.md",
     "LICENSE",
     "DESIGN.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coaia-narrative",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Creative Orientation AI Agentic Memories - Narrative Beat Extension with IAIP relational integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/schema/README.md
+++ b/schema/README.md
@@ -2,12 +2,28 @@
 
 This folder contains comprehensive schema documentation for the COAIA (Creative-Oriented AI Assistant) Narrative system. The schemas define both the data models and the MCP tool interfaces that applications can use to interact with structural tension charts and knowledge graphs.
 
+## 📐 Schema Format Convention
+
+**JSON is the canonical schema format.** All schema definitions live in `.json` files.
+
+YAML files (`.yaml`) are **generated** from their JSON counterparts and must not be edited manually:
+
+```bash
+# Regenerate all YAML files from JSON sources
+npm run schema:generate
+
+# Verify JSON/YAML parity (CI check)
+npm run schema:check
+```
+
+If you modify a `.json` schema, run `npm run schema:generate` to keep the YAML in sync.
+
 ## 📁 Quick Navigation
 
 ### Data Models
 - **[data-model/](data-model/)** - Core data structures (Entity, Relation, KnowledgeGraph, Storage Format)
-- **[data-model-complete.json](data-model-complete.json)** - ✨ **Single consolidated file** with all data schemas
-- **[data-model-complete.yaml](data-model-complete.yaml)** - Same as above in YAML format
+- **[data-model-complete.json](data-model-complete.json)** - ✨ **Single consolidated file** with all data schemas (canonical JSON)
+- **[data-model-complete.yaml](data-model-complete.yaml)** - Same as above in YAML format (generated)
 
 ### MCP Tools
 - **[tools/stc/](tools/stc/)** - Structural Tension Chart tools (11 tools)

--- a/schema/VOCABULARY.md
+++ b/schema/VOCABULARY.md
@@ -1,0 +1,120 @@
+# COAIA Narrative Schema Vocabulary
+
+This document defines the canonical vocabulary for enumerated fields in the COAIA Narrative schema.
+Canonical values are authoritative. Aliases are accepted by consumers for backward compatibility
+but **must not be produced by new code**.
+
+---
+
+## Enum Fields
+
+### `captureQuality`
+
+Describes the audio/capture quality of a narrative beat session.
+
+| Canonical Value | Meaning |
+|---|---|
+| `clear` | Clean capture; no significant ambient noise or interruptions |
+| `windy` | Outdoor session with wind noise affecting audio quality |
+| `partial` | Incomplete capture; transcript-only or significant data loss |
+
+**Closed enum** — only these three values are valid in new records.
+
+#### Aliases (backward compatibility only)
+
+| Alias | Canonical |
+|---|---|
+| `complete` | `clear` |
+| `noisy` | `windy` |
+| `transcript-only` | `partial` |
+
+---
+
+### `continuationKind`
+
+Describes how this session relates to prior sessions in a lineage.
+
+| Canonical Value | Meaning |
+|---|---|
+| `branch` | A new divergent session branched from a parent chart or session |
+| `parent-return` | Returning to the parent chart after working in a branch |
+| `follow-up` | A continuation of a prior session without a branch relationship |
+
+**Closed enum** — only these three values are valid in new records.
+
+#### Aliases (backward compatibility only)
+
+| Alias | Canonical |
+|---|---|
+| `new` | `branch` |
+| `resumption` | `follow-up` |
+| `branch-return` | `parent-return` |
+
+---
+
+### `setting`
+
+The physical setting where the session was captured.
+
+| Canonical Value | Meaning |
+|---|---|
+| `desk` | Indoor desk setup (default office/home environment) |
+| `walking` | Outdoor walking session (not specifically land-based learning) |
+| `land-based` | Intentional land-based learning context (nature immersion, fieldwork) |
+| `transit` | On transportation (train, car, bus) |
+| `unknown` | Setting was not recorded or is unclear |
+
+**Open enum** — additional values may be added in future versions without a breaking change.
+
+#### Aliases (backward compatibility only)
+
+| Alias | Canonical |
+|---|---|
+| `outdoor-walking` | `walking` |
+
+---
+
+### `mode`
+
+The interaction mode of the session.
+
+| Canonical Value | Meaning |
+|---|---|
+| `voice` | Primarily voice dictation or spoken interaction |
+| `terminal` | Primarily keyboard/terminal commands |
+| `mixed` | Combination of voice and terminal interaction |
+
+**Closed enum** — only these three values are valid in new records.
+
+No aliases defined for `mode`.
+
+---
+
+## Field Reference
+
+### `sessionContext` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `mode` | enum | See `mode` above |
+| `setting` | enum | See `setting` above |
+| `landBasedLearning` | boolean | `true` when session is intentionally conducted in nature for learning purposes |
+| `environmentNotes` | string | Free-text description of environmental conditions |
+| `listeningContext` | string | What was being reviewed or listened to during the session |
+| `captureQuality` | enum | See `captureQuality` above |
+| `continuationKind` | enum | See `continuationKind` above |
+| `privateChroniclePath` | string \| null | Path to private chronicle file; `null` if not applicable |
+| `publicSummaryAllowed` | boolean | Whether a public summary of this session may be published |
+
+---
+
+## Canonical vs Alias Policy
+
+- **Canonical values** are authoritative and defined in `schema/data-model/entity.json`.
+- **Aliases** are accepted by all COAIA consumers (MCP server, visualizer, CLI) for backward compatibility with older data.
+- **New code must produce canonical values only.** Aliases exist to avoid breaking existing JSONL files.
+- The alias mapping for the visualizer is tracked in [jgwill/coaia-visualizer#30](https://github.com/jgwill/coaia-visualizer/issues/30).
+
+---
+
+*This document is manually maintained. When adding new enum values, update both this file and `schema/data-model/entity.json`.*

--- a/schema/data-model-complete.json
+++ b/schema/data-model-complete.json
@@ -1,14 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/avadisabelle/coaia-narrative/schema/data-model-complete.json",
-  "title": "COAIA Complete Data Model",
-  "description": "Consolidated schema containing all data models used in the COAIA Narrative system. This single file provides a complete reference for the Entity structure, Relation structure, KnowledgeGraph container, and JSONL storage format.",
-  "version": "2.3.0",
+  "title": "COAIA Narrative Complete Data Model",
+  "description": "Combined schema definitions for all COAIA data structures",
   "definitions": {
     "Entity": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://github.com/avadisabelle/coaia-narrative/schema/data-model/entity.json",
+      "title": "COAIA Entity",
+      "description": "Core entity structure for COAIA memory system. Entities represent nodes in the knowledge graph with typed observations and rich metadata.",
       "type": "object",
-      "required": ["name", "entityType", "observations"],
-      "description": "Core entity structure representing nodes in the knowledge graph with typed observations and rich metadata",
+      "required": [
+        "name",
+        "entityType",
+        "observations"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -54,7 +59,11 @@
             },
             "phase": {
               "type": "string",
-              "enum": ["germination", "assimilation", "completion"],
+              "enum": [
+                "germination",
+                "assimilation",
+                "completion"
+              ],
               "description": "Creative phase of the chart or action (based on Robert Fritz's creative process)"
             },
             "completionStatus": {
@@ -114,7 +123,10 @@
                   "description": "Whether relational alignment has been assessed"
                 },
                 "score": {
-                  "type": ["number", "null"],
+                  "type": [
+                    "number",
+                    "null"
+                  ],
                   "description": "Alignment score (0-100) or null if not assessed",
                   "minimum": 0,
                   "maximum": 100
@@ -127,30 +139,51 @@
                   "description": "Array of aligned relational principles"
                 }
               },
-              "required": ["assessed", "score", "principles"]
+              "required": [
+                "assessed",
+                "score",
+                "principles"
+              ]
             },
             "fourDirections": {
               "type": "object",
               "description": "Four Directions wisdom framework assessment",
               "properties": {
                 "north_vision": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "North direction: Vision, clarity, big picture perspective"
                 },
                 "east_intention": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "East direction: Intention, new beginnings, illumination"
                 },
                 "south_emotion": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "South direction: Emotion, passion, relationships, heart wisdom"
                 },
                 "west_introspection": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "West direction: Introspection, reflection, lessons learned"
                 }
               },
-              "required": ["north_vision", "east_intention", "south_emotion", "west_introspection"]
+              "required": [
+                "north_vision",
+                "east_intention",
+                "south_emotion",
+                "west_introspection"
+              ]
             },
             "narrative": {
               "type": "object",
@@ -172,7 +205,11 @@
                   "description": "Lessons learned or insights derived from this narrative"
                 }
               },
-              "required": ["description", "prose", "lessons"]
+              "required": [
+                "description",
+                "prose",
+                "lessons"
+              ]
             },
             "foundation": {
               "type": "object",
@@ -226,17 +263,31 @@
                 },
                 "evaluationStatus": {
                   "type": "string",
-                  "enum": ["expected", "delegated", "produced", "evaluated"],
+                  "enum": [
+                    "expected",
+                    "delegated",
+                    "produced",
+                    "evaluated"
+                  ],
                   "description": "Current evaluation status of research: expected (planned), delegated (assigned), produced (completed), evaluated (reviewed)"
                 },
                 "privacyClass": {
                   "type": "string",
-                  "enum": ["public-safe", "private", "mixed"],
+                  "enum": [
+                    "public-safe",
+                    "private",
+                    "mixed"
+                  ],
                   "description": "Privacy classification of research data: public-safe (can be shared), private (confidential), mixed (requires filtering)"
                 },
                 "publicationStatus": {
                   "type": "string",
-                  "enum": ["planned", "draft", "reviewed", "published"],
+                  "enum": [
+                    "planned",
+                    "draft",
+                    "reviewed",
+                    "published"
+                  ],
                   "description": "Publication workflow status"
                 },
                 "commitHandles": {
@@ -295,8 +346,79 @@
                 },
                 "handoffState": {
                   "type": "string",
-                  "enum": ["requirements-created", "implementation-ready", "returned-to-parent"],
+                  "enum": [
+                    "requirements-created",
+                    "implementation-ready",
+                    "returned-to-parent"
+                  ],
                   "description": "State of handoff between parent and child sessions: requirements-created (initial), implementation-ready (actionable), returned-to-parent (completed handoff)"
+                }
+              }
+            },
+            "sessionContext": {
+              "type": "object",
+              "description": "Beat-level lived session context metadata capturing the embodied condition of working sessions. Records land-based learning, voice/terminal mode, environmental constraints, and continuity context.",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "voice",
+                    "terminal",
+                    "mixed"
+                  ],
+                  "description": "Interaction mode of the session: voice (audio capture), terminal (text-based), mixed (alternating)"
+                },
+                "setting": {
+                  "type": "string",
+                  "enum": [
+                    "desk",
+                    "walking",
+                    "land-based",
+                    "transit",
+                    "unknown"
+                  ],
+                  "description": "Physical setting where session took place: desk (stationary workspace), walking (ambulatory), land-based (outdoor learning), transit (in motion), unknown (unrecorded)"
+                },
+                "landBasedLearning": {
+                  "type": "boolean",
+                  "description": "Whether session engaged land-based learning practices (e.g., walking the land, outdoor observation)"
+                },
+                "environmentNotes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Environmental conditions and constraints affecting capture quality (e.g., 'wind', 'outdoor walking', 'traffic noise')"
+                },
+                "listeningContext": {
+                  "type": "string",
+                  "description": "Context about what user was listening to or engaging with during session (e.g., 'user listened to Atlas Chronicle while walking')"
+                },
+                "captureQuality": {
+                  "type": "string",
+                  "enum": [
+                    "clear",
+                    "windy",
+                    "partial"
+                  ],
+                  "description": "Quality of audio/text capture: clear (high quality), windy (environmental interference), partial (incomplete or interrupted)"
+                },
+                "continuationKind": {
+                  "type": "string",
+                  "enum": [
+                    "branch",
+                    "parent-return",
+                    "follow-up"
+                  ],
+                  "description": "Type of session continuation: branch (new thread), parent-return (returning to main), follow-up (sequential continuation)"
+                },
+                "privateChroniclePath": {
+                  "type": "string",
+                  "description": "File path to private chronicle recording or transcript (handle only, content not exposed by default)"
+                },
+                "publicSummaryAllowed": {
+                  "type": "boolean",
+                  "description": "Whether a public summary of this session context is permitted"
                 }
               }
             }
@@ -305,9 +427,16 @@
       }
     },
     "Relation": {
-      "type": "object",
-      "required": ["from", "to", "relationType"],
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://github.com/avadisabelle/coaia-narrative/schema/data-model/relation.json",
+      "title": "COAIA Relation",
       "description": "Relation structure connecting entities in the COAIA knowledge graph. Relations define typed connections with optional metadata for context and strength.",
+      "type": "object",
+      "required": [
+        "from",
+        "to",
+        "relationType"
+      ],
       "properties": {
         "from": {
           "type": "string",
@@ -365,93 +494,255 @@
             }
           }
         }
-      }
+      },
+      "examples": [
+        {
+          "from": "chart_123_current_reality",
+          "to": "chart_123_desired_outcome",
+          "relationType": "creates_tension_with",
+          "metadata": {
+            "description": "The gap between current reality and desired outcome creates productive structural tension",
+            "createdAt": "2026-02-13T07:00:00Z"
+          }
+        },
+        {
+          "from": "chart_123_action_1",
+          "to": "chart_123_desired_outcome",
+          "relationType": "advances_toward",
+          "metadata": {
+            "description": "Completing this action step moves the system closer to the desired outcome",
+            "strength": 0.8
+          }
+        },
+        {
+          "from": "chart_123_action_1",
+          "to": "chart_456",
+          "relationType": "telescopes_into",
+          "metadata": {
+            "description": "This action has been broken down into a detailed sub-chart"
+          }
+        },
+        {
+          "from": "chart_123_action_1",
+          "to": "chart_123_current_reality",
+          "relationType": "flows_into",
+          "metadata": {
+            "description": "Upon completion, this action's result becomes part of current reality",
+            "createdAt": "2026-02-13T08:00:00Z"
+          }
+        }
+      ]
     },
     "KnowledgeGraph": {
-      "type": "object",
-      "required": ["entities", "relations"],
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://github.com/avadisabelle/coaia-narrative/schema/data-model/knowledge-graph.json",
+      "title": "COAIA Knowledge Graph",
       "description": "Complete knowledge graph structure containing entities and relations. This is the in-memory representation of the graph.",
+      "type": "object",
+      "required": [
+        "entities",
+        "relations"
+      ],
       "properties": {
         "entities": {
           "type": "array",
           "description": "Array of all entities in the knowledge graph",
           "items": {
-            "$ref": "#/definitions/Entity"
+            "$ref": "entity.json"
           }
         },
         "relations": {
           "type": "array",
           "description": "Array of all relations connecting entities in the graph",
           "items": {
-            "$ref": "#/definitions/Relation"
+            "$ref": "relation.json"
           }
         }
-      }
-    },
-    "EntityStorageLine": {
-      "type": "object",
-      "required": ["type", "name", "entityType", "observations"],
-      "description": "Entity record as stored in JSONL format (single line)",
-      "properties": {
-        "type": {
-          "const": "entity",
-          "description": "Discriminator indicating this line contains an entity record"
-        },
-        "name": {
-          "type": "string",
-          "description": "Unique identifier for this entity"
-        },
-        "entityType": {
-          "type": "string",
-          "description": "Type of entity"
-        },
-        "observations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Array of observations/facts"
-        },
-        "metadata": {
-          "$ref": "#/definitions/Entity/properties/metadata"
+      },
+      "examples": [
+        {
+          "entities": [
+            {
+              "name": "chart_123",
+              "entityType": "structural_tension_chart",
+              "observations": [
+                "Python learning journey"
+              ],
+              "metadata": {
+                "dueDate": "2026-03-15T00:00:00Z",
+                "chartId": "chart_123",
+                "level": 0,
+                "createdAt": "2026-02-13T07:00:00Z"
+              }
+            },
+            {
+              "name": "chart_123_desired_outcome",
+              "entityType": "desired_outcome",
+              "observations": [
+                "Build and deploy a Python web application"
+              ],
+              "metadata": {
+                "chartId": "chart_123"
+              }
+            },
+            {
+              "name": "chart_123_current_reality",
+              "entityType": "current_reality",
+              "observations": [
+                "Know basic Python syntax",
+                "Never worked with web frameworks"
+              ],
+              "metadata": {
+                "chartId": "chart_123"
+              }
+            },
+            {
+              "name": "chart_123_action_1",
+              "entityType": "action_step",
+              "observations": [
+                "Complete Django tutorial"
+              ],
+              "metadata": {
+                "chartId": "chart_123",
+                "dueDate": "2026-02-20T00:00:00Z",
+                "completionStatus": false
+              }
+            }
+          ],
+          "relations": [
+            {
+              "from": "chart_123_current_reality",
+              "to": "chart_123_desired_outcome",
+              "relationType": "creates_tension_with"
+            },
+            {
+              "from": "chart_123_action_1",
+              "to": "chart_123_desired_outcome",
+              "relationType": "advances_toward"
+            }
+          ]
         }
-      }
+      ]
     },
-    "RelationStorageLine": {
-      "type": "object",
-      "required": ["type", "from", "to", "relationType"],
-      "description": "Relation record as stored in JSONL format (single line)",
-      "properties": {
-        "type": {
-          "const": "relation",
-          "description": "Discriminator indicating this line contains a relation record"
+    "StorageFormat": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://github.com/avadisabelle/coaia-narrative/schema/data-model/storage-format.json",
+      "title": "COAIA JSONL Storage Format",
+      "description": "Schema for structural tension chart data stored in JSONL (JSON Lines) format. Each line is either an Entity or Relation record with a type discriminator.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/EntityLine"
         },
-        "from": {
-          "type": "string",
-          "description": "Source entity name"
-        },
-        "to": {
-          "type": "string",
-          "description": "Target entity name"
-        },
-        "relationType": {
-          "type": "string",
-          "description": "Type of relationship"
-        },
-        "metadata": {
-          "$ref": "#/definitions/Relation/properties/metadata"
+        {
+          "$ref": "#/definitions/RelationLine"
         }
-      }
-    }
-  },
-  "description_extended": {
-    "purpose": "This schema defines the complete data model for the COAIA (Creative-Oriented AI Assistant) Narrative system, which implements structural tension charts based on Robert Fritz's creative methodology.",
-    "storage": "Data is stored in JSONL (JSON Lines) format where each line is either an EntityStorageLine or RelationStorageLine with a 'type' discriminator field.",
-    "in_memory": "Data is loaded into a KnowledgeGraph structure containing arrays of Entity and Relation objects.",
-    "key_concepts": {
-      "structural_tension": "The productive tension between current reality and desired outcome that drives creative advancement",
-      "telescoping": "Breaking down action steps into detailed sub-charts while maintaining structural integrity",
-      "advancing_patterns": "Completed actions flow into current reality, changing the structural dynamic and creating momentum"
+      ],
+      "definitions": {
+        "EntityLine": {
+          "type": "object",
+          "required": [
+            "type",
+            "name",
+            "entityType",
+            "observations"
+          ],
+          "properties": {
+            "type": {
+              "const": "entity",
+              "description": "Discriminator indicating this line contains an entity record"
+            },
+            "name": {
+              "type": "string",
+              "description": "Unique identifier for this entity. For structural tension components, follows naming convention: 'chart_{id}_{component}'"
+            },
+            "entityType": {
+              "type": "string",
+              "description": "Type of entity defining its role in the system",
+              "enum": [
+                "structural_tension_chart",
+                "desired_outcome",
+                "current_reality",
+                "action_step",
+                "narrative_beat",
+                "person",
+                "concept",
+                "event",
+                "location",
+                "organization",
+                "artifact",
+                "custom"
+              ]
+            },
+            "observations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of observations/facts about this entity"
+            },
+            "metadata": {
+              "type": "object",
+              "description": "Optional metadata (see entity.json schema for full specification)"
+            }
+          }
+        },
+        "RelationLine": {
+          "type": "object",
+          "required": [
+            "type",
+            "from",
+            "to",
+            "relationType"
+          ],
+          "properties": {
+            "type": {
+              "const": "relation",
+              "description": "Discriminator indicating this line contains a relation record"
+            },
+            "from": {
+              "type": "string",
+              "description": "Source entity name (must match an existing entity's name field)"
+            },
+            "to": {
+              "type": "string",
+              "description": "Target entity name (must match an existing entity's name field)"
+            },
+            "relationType": {
+              "type": "string",
+              "description": "Type of relationship between entities",
+              "enum": [
+                "creates_tension_with",
+                "advances_toward",
+                "telescopes_into",
+                "flows_into",
+                "part_of",
+                "related_to",
+                "depends_on",
+                "influences",
+                "precedes",
+                "follows",
+                "contains",
+                "member_of",
+                "owns",
+                "created_by",
+                "mentions",
+                "references",
+                "custom"
+              ]
+            },
+            "metadata": {
+              "type": "object",
+              "description": "Optional metadata (see relation.json schema for full specification)"
+            }
+          }
+        }
+      },
+      "examples": [
+        "{\"type\":\"entity\",\"name\":\"chart_123\",\"entityType\":\"structural_tension_chart\",\"observations\":[\"Python learning journey\"],\"metadata\":{\"chartId\":\"chart_123\",\"dueDate\":\"2026-03-15T00:00:00Z\",\"level\":0}}",
+        "{\"type\":\"entity\",\"name\":\"chart_123_desired_outcome\",\"entityType\":\"desired_outcome\",\"observations\":[\"Build and deploy a Python web application\"],\"metadata\":{\"chartId\":\"chart_123\"}}",
+        "{\"type\":\"entity\",\"name\":\"chart_123_current_reality\",\"entityType\":\"current_reality\",\"observations\":[\"Know basic Python syntax\",\"Never worked with web frameworks\"],\"metadata\":{\"chartId\":\"chart_123\"}}",
+        "{\"type\":\"relation\",\"from\":\"chart_123_current_reality\",\"to\":\"chart_123_desired_outcome\",\"relationType\":\"creates_tension_with\"}"
+      ]
     }
   }
 }

--- a/schema/data-model-complete.json
+++ b/schema/data-model-complete.json
@@ -173,6 +173,132 @@
                 }
               },
               "required": ["description", "prose", "lessons"]
+            },
+            "foundation": {
+              "type": "object",
+              "description": "Deep Research Foundations metadata tracking research packet context and evaluation status. Used by Atlas Chronicle and research delegation workflows.",
+              "properties": {
+                "packetRoot": {
+                  "type": "string",
+                  "description": "Root identifier for research packet (e.g., 'foundations/atlas-chronicle/')"
+                },
+                "foundationType": {
+                  "type": "string",
+                  "description": "Type of foundation research (e.g., 'atlas-chronicle', 'inquiry', 'baseline')"
+                },
+                "parentIssue": {
+                  "type": "string",
+                  "description": "GitHub issue reference for parent research context (e.g., 'owner/repo#number')"
+                },
+                "baselineIssue": {
+                  "type": "string",
+                  "description": "GitHub issue establishing baseline requirements"
+                },
+                "inquiryIssue": {
+                  "type": "string",
+                  "description": "GitHub issue defining research inquiry"
+                },
+                "protocolIssue": {
+                  "type": "string",
+                  "description": "GitHub issue documenting research protocol"
+                },
+                "schemaIssue": {
+                  "type": "string",
+                  "description": "GitHub issue defining data schema"
+                },
+                "visualizerIssue": {
+                  "type": "string",
+                  "description": "GitHub issue for visualization specifications"
+                },
+                "expectedArtifacts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of expected research artifacts/deliverables"
+                },
+                "producedArtifacts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of produced research artifacts/deliverables"
+                },
+                "evaluationStatus": {
+                  "type": "string",
+                  "enum": ["expected", "delegated", "produced", "evaluated"],
+                  "description": "Current evaluation status of research: expected (planned), delegated (assigned), produced (completed), evaluated (reviewed)"
+                },
+                "privacyClass": {
+                  "type": "string",
+                  "enum": ["public-safe", "private", "mixed"],
+                  "description": "Privacy classification of research data: public-safe (can be shared), private (confidential), mixed (requires filtering)"
+                },
+                "publicationStatus": {
+                  "type": "string",
+                  "enum": ["planned", "draft", "reviewed", "published"],
+                  "description": "Publication workflow status"
+                },
+                "commitHandles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Associated commit hashes or version control handles"
+                }
+              }
+            },
+            "sessionLineage": {
+              "type": "object",
+              "description": "Hermes session lineage metadata tracking conversation branching and handoff state. Enables reconstruction of session branch maps and parent-child traceability.",
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "description": "Platform where session originated (e.g., 'telegram', 'hermes', 'slack')"
+                },
+                "parentChartId": {
+                  "type": "string",
+                  "description": "Parent chart ID if session is branched from a parent context"
+                },
+                "sourceBeat": {
+                  "type": "string",
+                  "description": "Source narrative beat entity name that triggered session branching"
+                },
+                "originalSessionId": {
+                  "type": "string",
+                  "description": "Original session identifier before any branching occurred"
+                },
+                "branchSessionId": {
+                  "type": "string",
+                  "description": "Session ID of this specific branch point"
+                },
+                "branchIndex": {
+                  "type": "integer",
+                  "description": "Index of this branch among siblings (e.g., branch 1, 2, 3...)",
+                  "minimum": 0
+                },
+                "copiedMessageCount": {
+                  "type": "integer",
+                  "description": "Number of messages copied from parent session to this branch",
+                  "minimum": 0
+                },
+                "branchPurpose": {
+                  "type": "string",
+                  "description": "Purpose or reason for creating this session branch"
+                },
+                "relatedIssues": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Related GitHub issue references (e.g., 'owner/repo#number')"
+                },
+                "handoffState": {
+                  "type": "string",
+                  "enum": ["requirements-created", "implementation-ready", "returned-to-parent"],
+                  "description": "State of handoff between parent and child sessions: requirements-created (initial), implementation-ready (actionable), returned-to-parent (completed handoff)"
+                }
+              }
             }
           }
         }

--- a/schema/data-model-complete.yaml
+++ b/schema/data-model-complete.yaml
@@ -1,21 +1,19 @@
 $schema: http://json-schema.org/draft-07/schema#
-$id: https://github.com/avadisabelle/coaia-narrative/schema/data-model-complete.json
-title: COAIA Complete Data Model
-description: >-
-  Consolidated schema containing all data models used in the COAIA Narrative system. This single
-  file provides a complete reference for the Entity structure, Relation structure, KnowledgeGraph
-  container, and JSONL storage format.
-version: 2.3.0
+title: COAIA Narrative Complete Data Model
+description: Combined schema definitions for all COAIA data structures
 definitions:
   Entity:
+    $schema: http://json-schema.org/draft-07/schema#
+    $id: https://github.com/avadisabelle/coaia-narrative/schema/data-model/entity.json
+    title: COAIA Entity
+    description: >-
+      Core entity structure for COAIA memory system. Entities represent nodes in the knowledge graph
+      with typed observations and rich metadata.
     type: object
     required:
       - name
       - entityType
       - observations
-    description: >-
-      Core entity structure representing nodes in the knowledge graph with typed observations and
-      rich metadata
     properties:
       name:
         type: string
@@ -177,15 +175,208 @@ definitions:
               - description
               - prose
               - lessons
+          foundation:
+            type: object
+            description: >-
+              Deep Research Foundations metadata tracking research packet context and evaluation
+              status. Used by Atlas Chronicle and research delegation workflows.
+            properties:
+              packetRoot:
+                type: string
+                description: Root identifier for research packet (e.g., 'foundations/atlas-chronicle/')
+              foundationType:
+                type: string
+                description: Type of foundation research (e.g., 'atlas-chronicle', 'inquiry', 'baseline')
+              parentIssue:
+                type: string
+                description: GitHub issue reference for parent research context (e.g., 'owner/repo#number')
+              baselineIssue:
+                type: string
+                description: GitHub issue establishing baseline requirements
+              inquiryIssue:
+                type: string
+                description: GitHub issue defining research inquiry
+              protocolIssue:
+                type: string
+                description: GitHub issue documenting research protocol
+              schemaIssue:
+                type: string
+                description: GitHub issue defining data schema
+              visualizerIssue:
+                type: string
+                description: GitHub issue for visualization specifications
+              expectedArtifacts:
+                type: array
+                items:
+                  type: string
+                description: List of expected research artifacts/deliverables
+              producedArtifacts:
+                type: array
+                items:
+                  type: string
+                description: List of produced research artifacts/deliverables
+              evaluationStatus:
+                type: string
+                enum:
+                  - expected
+                  - delegated
+                  - produced
+                  - evaluated
+                description: >-
+                  Current evaluation status of research: expected (planned), delegated (assigned),
+                  produced (completed), evaluated (reviewed)
+              privacyClass:
+                type: string
+                enum:
+                  - public-safe
+                  - private
+                  - mixed
+                description: >-
+                  Privacy classification of research data: public-safe (can be shared), private
+                  (confidential), mixed (requires filtering)
+              publicationStatus:
+                type: string
+                enum:
+                  - planned
+                  - draft
+                  - reviewed
+                  - published
+                description: Publication workflow status
+              commitHandles:
+                type: array
+                items:
+                  type: string
+                description: Associated commit hashes or version control handles
+          sessionLineage:
+            type: object
+            description: >-
+              Hermes session lineage metadata tracking conversation branching and handoff state.
+              Enables reconstruction of session branch maps and parent-child traceability.
+            properties:
+              platform:
+                type: string
+                description: Platform where session originated (e.g., 'telegram', 'hermes', 'slack')
+              parentChartId:
+                type: string
+                description: Parent chart ID if session is branched from a parent context
+              sourceBeat:
+                type: string
+                description: Source narrative beat entity name that triggered session branching
+              originalSessionId:
+                type: string
+                description: Original session identifier before any branching occurred
+              branchSessionId:
+                type: string
+                description: Session ID of this specific branch point
+              branchIndex:
+                type: integer
+                description: Index of this branch among siblings (e.g., branch 1, 2, 3...)
+                minimum: 0
+              copiedMessageCount:
+                type: integer
+                description: Number of messages copied from parent session to this branch
+                minimum: 0
+              branchPurpose:
+                type: string
+                description: Purpose or reason for creating this session branch
+              relatedIssues:
+                type: array
+                items:
+                  type: string
+                description: Related GitHub issue references (e.g., 'owner/repo#number')
+              handoffState:
+                type: string
+                enum:
+                  - requirements-created
+                  - implementation-ready
+                  - returned-to-parent
+                description: >-
+                  State of handoff between parent and child sessions: requirements-created
+                  (initial), implementation-ready (actionable), returned-to-parent (completed
+                  handoff)
+          sessionContext:
+            type: object
+            description: >-
+              Beat-level lived session context metadata capturing the embodied condition of working
+              sessions. Records land-based learning, voice/terminal mode, environmental constraints,
+              and continuity context.
+            properties:
+              mode:
+                type: string
+                enum:
+                  - voice
+                  - terminal
+                  - mixed
+                description: >-
+                  Interaction mode of the session: voice (audio capture), terminal (text-based),
+                  mixed (alternating)
+              setting:
+                type: string
+                enum:
+                  - desk
+                  - walking
+                  - land-based
+                  - transit
+                  - unknown
+                description: >-
+                  Physical setting where session took place: desk (stationary workspace), walking
+                  (ambulatory), land-based (outdoor learning), transit (in motion), unknown
+                  (unrecorded)
+              landBasedLearning:
+                type: boolean
+                description: >-
+                  Whether session engaged land-based learning practices (e.g., walking the land,
+                  outdoor observation)
+              environmentNotes:
+                type: array
+                items:
+                  type: string
+                description: >-
+                  Environmental conditions and constraints affecting capture quality (e.g., 'wind',
+                  'outdoor walking', 'traffic noise')
+              listeningContext:
+                type: string
+                description: >-
+                  Context about what user was listening to or engaging with during session (e.g.,
+                  'user listened to Atlas Chronicle while walking')
+              captureQuality:
+                type: string
+                enum:
+                  - clear
+                  - windy
+                  - partial
+                description: >-
+                  Quality of audio/text capture: clear (high quality), windy (environmental
+                  interference), partial (incomplete or interrupted)
+              continuationKind:
+                type: string
+                enum:
+                  - branch
+                  - parent-return
+                  - follow-up
+                description: >-
+                  Type of session continuation: branch (new thread), parent-return (returning to
+                  main), follow-up (sequential continuation)
+              privateChroniclePath:
+                type: string
+                description: >-
+                  File path to private chronicle recording or transcript (handle only, content not
+                  exposed by default)
+              publicSummaryAllowed:
+                type: boolean
+                description: Whether a public summary of this session context is permitted
   Relation:
+    $schema: http://json-schema.org/draft-07/schema#
+    $id: https://github.com/avadisabelle/coaia-narrative/schema/data-model/relation.json
+    title: COAIA Relation
+    description: >-
+      Relation structure connecting entities in the COAIA knowledge graph. Relations define typed
+      connections with optional metadata for context and strength.
     type: object
     required:
       - from
       - to
       - relationType
-    description: >-
-      Relation structure connecting entities in the COAIA knowledge graph. Relations define typed
-      connections with optional metadata for context and strength.
     properties:
       from:
         type: string
@@ -233,87 +424,195 @@ definitions:
           description:
             type: string
             description: Human-readable description of the relation
+    examples:
+      - from: chart_123_current_reality
+        to: chart_123_desired_outcome
+        relationType: creates_tension_with
+        metadata:
+          description: >-
+            The gap between current reality and desired outcome creates productive structural
+            tension
+          createdAt: '2026-02-13T07:00:00Z'
+      - from: chart_123_action_1
+        to: chart_123_desired_outcome
+        relationType: advances_toward
+        metadata:
+          description: Completing this action step moves the system closer to the desired outcome
+          strength: 0.8
+      - from: chart_123_action_1
+        to: chart_456
+        relationType: telescopes_into
+        metadata:
+          description: This action has been broken down into a detailed sub-chart
+      - from: chart_123_action_1
+        to: chart_123_current_reality
+        relationType: flows_into
+        metadata:
+          description: Upon completion, this action's result becomes part of current reality
+          createdAt: '2026-02-13T08:00:00Z'
   KnowledgeGraph:
+    $schema: http://json-schema.org/draft-07/schema#
+    $id: https://github.com/avadisabelle/coaia-narrative/schema/data-model/knowledge-graph.json
+    title: COAIA Knowledge Graph
+    description: >-
+      Complete knowledge graph structure containing entities and relations. This is the in-memory
+      representation of the graph.
     type: object
     required:
       - entities
       - relations
-    description: >-
-      Complete knowledge graph structure containing entities and relations. This is the in-memory
-      representation of the graph.
     properties:
       entities:
         type: array
         description: Array of all entities in the knowledge graph
         items:
-          $ref: '#/definitions/Entity'
+          $ref: entity.json
       relations:
         type: array
         description: Array of all relations connecting entities in the graph
         items:
-          $ref: '#/definitions/Relation'
-  EntityStorageLine:
-    type: object
-    required:
-      - type
-      - name
-      - entityType
-      - observations
-    description: Entity record as stored in JSONL format (single line)
-    properties:
-      type:
-        const: entity
-        description: Discriminator indicating this line contains an entity record
-      name:
-        type: string
-        description: Unique identifier for this entity
-      entityType:
-        type: string
-        description: Type of entity
-      observations:
-        type: array
-        items:
-          type: string
-        description: Array of observations/facts
-      metadata:
-        $ref: '#/definitions/Entity/properties/metadata'
-  RelationStorageLine:
-    type: object
-    required:
-      - type
-      - from
-      - to
-      - relationType
-    description: Relation record as stored in JSONL format (single line)
-    properties:
-      type:
-        const: relation
-        description: Discriminator indicating this line contains a relation record
-      from:
-        type: string
-        description: Source entity name
-      to:
-        type: string
-        description: Target entity name
-      relationType:
-        type: string
-        description: Type of relationship
-      metadata:
-        $ref: '#/definitions/Relation/properties/metadata'
-description_extended:
-  purpose: >-
-    This schema defines the complete data model for the COAIA (Creative-Oriented AI Assistant)
-    Narrative system, which implements structural tension charts based on Robert Fritz's creative
-    methodology.
-  storage: >-
-    Data is stored in JSONL (JSON Lines) format where each line is either an EntityStorageLine or
-    RelationStorageLine with a 'type' discriminator field.
-  in_memory: Data is loaded into a KnowledgeGraph structure containing arrays of Entity and Relation objects.
-  key_concepts:
-    structural_tension: >-
-      The productive tension between current reality and desired outcome that drives creative
-      advancement
-    telescoping: Breaking down action steps into detailed sub-charts while maintaining structural integrity
-    advancing_patterns: >-
-      Completed actions flow into current reality, changing the structural dynamic and creating
-      momentum
+          $ref: relation.json
+    examples:
+      - entities:
+          - name: chart_123
+            entityType: structural_tension_chart
+            observations:
+              - Python learning journey
+            metadata:
+              dueDate: '2026-03-15T00:00:00Z'
+              chartId: chart_123
+              level: 0
+              createdAt: '2026-02-13T07:00:00Z'
+          - name: chart_123_desired_outcome
+            entityType: desired_outcome
+            observations:
+              - Build and deploy a Python web application
+            metadata:
+              chartId: chart_123
+          - name: chart_123_current_reality
+            entityType: current_reality
+            observations:
+              - Know basic Python syntax
+              - Never worked with web frameworks
+            metadata:
+              chartId: chart_123
+          - name: chart_123_action_1
+            entityType: action_step
+            observations:
+              - Complete Django tutorial
+            metadata:
+              chartId: chart_123
+              dueDate: '2026-02-20T00:00:00Z'
+              completionStatus: false
+        relations:
+          - from: chart_123_current_reality
+            to: chart_123_desired_outcome
+            relationType: creates_tension_with
+          - from: chart_123_action_1
+            to: chart_123_desired_outcome
+            relationType: advances_toward
+  StorageFormat:
+    $schema: http://json-schema.org/draft-07/schema#
+    $id: https://github.com/avadisabelle/coaia-narrative/schema/data-model/storage-format.json
+    title: COAIA JSONL Storage Format
+    description: >-
+      Schema for structural tension chart data stored in JSONL (JSON Lines) format. Each line is
+      either an Entity or Relation record with a type discriminator.
+    oneOf:
+      - $ref: '#/definitions/EntityLine'
+      - $ref: '#/definitions/RelationLine'
+    definitions:
+      EntityLine:
+        type: object
+        required:
+          - type
+          - name
+          - entityType
+          - observations
+        properties:
+          type:
+            const: entity
+            description: Discriminator indicating this line contains an entity record
+          name:
+            type: string
+            description: >-
+              Unique identifier for this entity. For structural tension components, follows naming
+              convention: 'chart_{id}_{component}'
+          entityType:
+            type: string
+            description: Type of entity defining its role in the system
+            enum:
+              - structural_tension_chart
+              - desired_outcome
+              - current_reality
+              - action_step
+              - narrative_beat
+              - person
+              - concept
+              - event
+              - location
+              - organization
+              - artifact
+              - custom
+          observations:
+            type: array
+            items:
+              type: string
+            description: Array of observations/facts about this entity
+          metadata:
+            type: object
+            description: Optional metadata (see entity.json schema for full specification)
+      RelationLine:
+        type: object
+        required:
+          - type
+          - from
+          - to
+          - relationType
+        properties:
+          type:
+            const: relation
+            description: Discriminator indicating this line contains a relation record
+          from:
+            type: string
+            description: Source entity name (must match an existing entity's name field)
+          to:
+            type: string
+            description: Target entity name (must match an existing entity's name field)
+          relationType:
+            type: string
+            description: Type of relationship between entities
+            enum:
+              - creates_tension_with
+              - advances_toward
+              - telescopes_into
+              - flows_into
+              - part_of
+              - related_to
+              - depends_on
+              - influences
+              - precedes
+              - follows
+              - contains
+              - member_of
+              - owns
+              - created_by
+              - mentions
+              - references
+              - custom
+          metadata:
+            type: object
+            description: Optional metadata (see relation.json schema for full specification)
+    examples:
+      - >-
+        {"type":"entity","name":"chart_123","entityType":"structural_tension_chart","observations":["Python
+        learning
+        journey"],"metadata":{"chartId":"chart_123","dueDate":"2026-03-15T00:00:00Z","level":0}}
+      - >-
+        {"type":"entity","name":"chart_123_desired_outcome","entityType":"desired_outcome","observations":["Build
+        and deploy a Python web application"],"metadata":{"chartId":"chart_123"}}
+      - >-
+        {"type":"entity","name":"chart_123_current_reality","entityType":"current_reality","observations":["Know
+        basic Python syntax","Never worked with web frameworks"],"metadata":{"chartId":"chart_123"}}
+      - >-
+        {"type":"relation","from":"chart_123_current_reality","to":"chart_123_desired_outcome","relationType":"creates_tension_with"}

--- a/schema/data-model/entity.json
+++ b/schema/data-model/entity.json
@@ -169,6 +169,132 @@
             }
           },
           "required": ["description", "prose", "lessons"]
+        },
+        "foundation": {
+          "type": "object",
+          "description": "Deep Research Foundations metadata tracking research packet context and evaluation status. Used by Atlas Chronicle and research delegation workflows.",
+          "properties": {
+            "packetRoot": {
+              "type": "string",
+              "description": "Root identifier for research packet (e.g., 'foundations/atlas-chronicle/')"
+            },
+            "foundationType": {
+              "type": "string",
+              "description": "Type of foundation research (e.g., 'atlas-chronicle', 'inquiry', 'baseline')"
+            },
+            "parentIssue": {
+              "type": "string",
+              "description": "GitHub issue reference for parent research context (e.g., 'owner/repo#number')"
+            },
+            "baselineIssue": {
+              "type": "string",
+              "description": "GitHub issue establishing baseline requirements"
+            },
+            "inquiryIssue": {
+              "type": "string",
+              "description": "GitHub issue defining research inquiry"
+            },
+            "protocolIssue": {
+              "type": "string",
+              "description": "GitHub issue documenting research protocol"
+            },
+            "schemaIssue": {
+              "type": "string",
+              "description": "GitHub issue defining data schema"
+            },
+            "visualizerIssue": {
+              "type": "string",
+              "description": "GitHub issue for visualization specifications"
+            },
+            "expectedArtifacts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of expected research artifacts/deliverables"
+            },
+            "producedArtifacts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of produced research artifacts/deliverables"
+            },
+            "evaluationStatus": {
+              "type": "string",
+              "enum": ["expected", "delegated", "produced", "evaluated"],
+              "description": "Current evaluation status of research: expected (planned), delegated (assigned), produced (completed), evaluated (reviewed)"
+            },
+            "privacyClass": {
+              "type": "string",
+              "enum": ["public-safe", "private", "mixed"],
+              "description": "Privacy classification of research data: public-safe (can be shared), private (confidential), mixed (requires filtering)"
+            },
+            "publicationStatus": {
+              "type": "string",
+              "enum": ["planned", "draft", "reviewed", "published"],
+              "description": "Publication workflow status"
+            },
+            "commitHandles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Associated commit hashes or version control handles"
+            }
+          }
+        },
+        "sessionLineage": {
+          "type": "object",
+          "description": "Hermes session lineage metadata tracking conversation branching and handoff state. Enables reconstruction of session branch maps and parent-child traceability.",
+          "properties": {
+            "platform": {
+              "type": "string",
+              "description": "Platform where session originated (e.g., 'telegram', 'hermes', 'slack')"
+            },
+            "parentChartId": {
+              "type": "string",
+              "description": "Parent chart ID if session is branched from a parent context"
+            },
+            "sourceBeat": {
+              "type": "string",
+              "description": "Source narrative beat entity name that triggered session branching"
+            },
+            "originalSessionId": {
+              "type": "string",
+              "description": "Original session identifier before any branching occurred"
+            },
+            "branchSessionId": {
+              "type": "string",
+              "description": "Session ID of this specific branch point"
+            },
+            "branchIndex": {
+              "type": "integer",
+              "description": "Index of this branch among siblings (e.g., branch 1, 2, 3...)",
+              "minimum": 0
+            },
+            "copiedMessageCount": {
+              "type": "integer",
+              "description": "Number of messages copied from parent session to this branch",
+              "minimum": 0
+            },
+            "branchPurpose": {
+              "type": "string",
+              "description": "Purpose or reason for creating this session branch"
+            },
+            "relatedIssues": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Related GitHub issue references (e.g., 'owner/repo#number')"
+            },
+            "handoffState": {
+              "type": "string",
+              "enum": ["requirements-created", "implementation-ready", "returned-to-parent"],
+              "description": "State of handoff between parent and child sessions: requirements-created (initial), implementation-ready (actionable), returned-to-parent (completed handoff)"
+            }
+          }
         }
       }
     }

--- a/schema/data-model/entity.json
+++ b/schema/data-model/entity.json
@@ -295,6 +295,55 @@
               "description": "State of handoff between parent and child sessions: requirements-created (initial), implementation-ready (actionable), returned-to-parent (completed handoff)"
             }
           }
+        },
+        "sessionContext": {
+          "type": "object",
+          "description": "Beat-level lived session context metadata capturing the embodied condition of working sessions. Records land-based learning, voice/terminal mode, environmental constraints, and continuity context.",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["voice", "terminal", "mixed"],
+              "description": "Interaction mode of the session: voice (audio capture), terminal (text-based), mixed (alternating)"
+            },
+            "setting": {
+              "type": "string",
+              "enum": ["desk", "walking", "land-based", "transit", "unknown"],
+              "description": "Physical setting where session took place: desk (stationary workspace), walking (ambulatory), land-based (outdoor learning), transit (in motion), unknown (unrecorded)"
+            },
+            "landBasedLearning": {
+              "type": "boolean",
+              "description": "Whether session engaged land-based learning practices (e.g., walking the land, outdoor observation)"
+            },
+            "environmentNotes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Environmental conditions and constraints affecting capture quality (e.g., 'wind', 'outdoor walking', 'traffic noise')"
+            },
+            "listeningContext": {
+              "type": "string",
+              "description": "Context about what user was listening to or engaging with during session (e.g., 'user listened to Atlas Chronicle while walking')"
+            },
+            "captureQuality": {
+              "type": "string",
+              "enum": ["clear", "windy", "partial"],
+              "description": "Quality of audio/text capture: clear (high quality), windy (environmental interference), partial (incomplete or interrupted)"
+            },
+            "continuationKind": {
+              "type": "string",
+              "enum": ["branch", "parent-return", "follow-up"],
+              "description": "Type of session continuation: branch (new thread), parent-return (returning to main), follow-up (sequential continuation)"
+            },
+            "privateChroniclePath": {
+              "type": "string",
+              "description": "File path to private chronicle recording or transcript (handle only, content not exposed by default)"
+            },
+            "publicSummaryAllowed": {
+              "type": "boolean",
+              "description": "Whether a public summary of this session context is permitted"
+            }
+          }
         }
       }
     }

--- a/schema/data-model/entity.yaml
+++ b/schema/data-model/entity.yaml
@@ -167,3 +167,191 @@ properties:
           - description
           - prose
           - lessons
+      foundation:
+        type: object
+        description: >-
+          Deep Research Foundations metadata tracking research packet context and evaluation status.
+          Used by Atlas Chronicle and research delegation workflows.
+        properties:
+          packetRoot:
+            type: string
+            description: Root identifier for research packet (e.g., 'foundations/atlas-chronicle/')
+          foundationType:
+            type: string
+            description: Type of foundation research (e.g., 'atlas-chronicle', 'inquiry', 'baseline')
+          parentIssue:
+            type: string
+            description: GitHub issue reference for parent research context (e.g., 'owner/repo#number')
+          baselineIssue:
+            type: string
+            description: GitHub issue establishing baseline requirements
+          inquiryIssue:
+            type: string
+            description: GitHub issue defining research inquiry
+          protocolIssue:
+            type: string
+            description: GitHub issue documenting research protocol
+          schemaIssue:
+            type: string
+            description: GitHub issue defining data schema
+          visualizerIssue:
+            type: string
+            description: GitHub issue for visualization specifications
+          expectedArtifacts:
+            type: array
+            items:
+              type: string
+            description: List of expected research artifacts/deliverables
+          producedArtifacts:
+            type: array
+            items:
+              type: string
+            description: List of produced research artifacts/deliverables
+          evaluationStatus:
+            type: string
+            enum:
+              - expected
+              - delegated
+              - produced
+              - evaluated
+            description: >-
+              Current evaluation status of research: expected (planned), delegated (assigned),
+              produced (completed), evaluated (reviewed)
+          privacyClass:
+            type: string
+            enum:
+              - public-safe
+              - private
+              - mixed
+            description: >-
+              Privacy classification of research data: public-safe (can be shared), private
+              (confidential), mixed (requires filtering)
+          publicationStatus:
+            type: string
+            enum:
+              - planned
+              - draft
+              - reviewed
+              - published
+            description: Publication workflow status
+          commitHandles:
+            type: array
+            items:
+              type: string
+            description: Associated commit hashes or version control handles
+      sessionLineage:
+        type: object
+        description: >-
+          Hermes session lineage metadata tracking conversation branching and handoff state. Enables
+          reconstruction of session branch maps and parent-child traceability.
+        properties:
+          platform:
+            type: string
+            description: Platform where session originated (e.g., 'telegram', 'hermes', 'slack')
+          parentChartId:
+            type: string
+            description: Parent chart ID if session is branched from a parent context
+          sourceBeat:
+            type: string
+            description: Source narrative beat entity name that triggered session branching
+          originalSessionId:
+            type: string
+            description: Original session identifier before any branching occurred
+          branchSessionId:
+            type: string
+            description: Session ID of this specific branch point
+          branchIndex:
+            type: integer
+            description: Index of this branch among siblings (e.g., branch 1, 2, 3...)
+            minimum: 0
+          copiedMessageCount:
+            type: integer
+            description: Number of messages copied from parent session to this branch
+            minimum: 0
+          branchPurpose:
+            type: string
+            description: Purpose or reason for creating this session branch
+          relatedIssues:
+            type: array
+            items:
+              type: string
+            description: Related GitHub issue references (e.g., 'owner/repo#number')
+          handoffState:
+            type: string
+            enum:
+              - requirements-created
+              - implementation-ready
+              - returned-to-parent
+            description: >-
+              State of handoff between parent and child sessions: requirements-created (initial),
+              implementation-ready (actionable), returned-to-parent (completed handoff)
+      sessionContext:
+        type: object
+        description: >-
+          Beat-level lived session context metadata capturing the embodied condition of working
+          sessions. Records land-based learning, voice/terminal mode, environmental constraints, and
+          continuity context.
+        properties:
+          mode:
+            type: string
+            enum:
+              - voice
+              - terminal
+              - mixed
+            description: >-
+              Interaction mode of the session: voice (audio capture), terminal (text-based), mixed
+              (alternating)
+          setting:
+            type: string
+            enum:
+              - desk
+              - walking
+              - land-based
+              - transit
+              - unknown
+            description: >-
+              Physical setting where session took place: desk (stationary workspace), walking
+              (ambulatory), land-based (outdoor learning), transit (in motion), unknown (unrecorded)
+          landBasedLearning:
+            type: boolean
+            description: >-
+              Whether session engaged land-based learning practices (e.g., walking the land, outdoor
+              observation)
+          environmentNotes:
+            type: array
+            items:
+              type: string
+            description: >-
+              Environmental conditions and constraints affecting capture quality (e.g., 'wind',
+              'outdoor walking', 'traffic noise')
+          listeningContext:
+            type: string
+            description: >-
+              Context about what user was listening to or engaging with during session (e.g., 'user
+              listened to Atlas Chronicle while walking')
+          captureQuality:
+            type: string
+            enum:
+              - clear
+              - windy
+              - partial
+            description: >-
+              Quality of audio/text capture: clear (high quality), windy (environmental
+              interference), partial (incomplete or interrupted)
+          continuationKind:
+            type: string
+            enum:
+              - branch
+              - parent-return
+              - follow-up
+            description: >-
+              Type of session continuation: branch (new thread), parent-return (returning to main),
+              follow-up (sequential continuation)
+          privateChroniclePath:
+            type: string
+            description: >-
+              File path to private chronicle recording or transcript (handle only, content not
+              exposed by default)
+          publicSummaryAllowed:
+            type: boolean
+            description: Whether a public summary of this session context is permitted

--- a/scripts/check-schema-parity.cjs
+++ b/scripts/check-schema-parity.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const assert = require('assert');
+
+const ROOT = path.resolve(__dirname, '..');
+const GENERATE = process.argv.includes('--generate');
+
+const pairs = [
+  ['schema/data-model/entity.json', 'schema/data-model/entity.yaml'],
+  ['schema/data-model-complete.json', 'schema/data-model-complete.yaml'],
+];
+
+let errors = 0;
+
+for (const [jsonRel, yamlRel] of pairs) {
+  const jsonPath = path.join(ROOT, jsonRel);
+  const yamlPath = path.join(ROOT, yamlRel);
+
+  if (!fs.existsSync(jsonPath)) {
+    console.error(`❌ Missing JSON source: ${jsonRel}`);
+    errors++;
+    continue;
+  }
+
+  const jsonData = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+
+  if (GENERATE) {
+    fs.writeFileSync(yamlPath, yaml.dump(jsonData, { indent: 2, lineWidth: 100, noRefs: true }));
+    console.log(`✅ Generated ${yamlRel}`);
+    continue;
+  }
+
+  if (!fs.existsSync(yamlPath)) {
+    console.error(`❌ Missing YAML file: ${yamlRel} (run with --generate to create)`);
+    errors++;
+    continue;
+  }
+
+  const yamlData = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+
+  try {
+    assert.deepStrictEqual(yamlData, jsonData, `Parity mismatch: ${jsonRel} vs ${yamlRel}`);
+    console.log(`✅ Parity OK: ${jsonRel}`);
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    errors++;
+  }
+}
+
+if (!GENERATE) {
+  if (errors > 0) {
+    console.error(`\n${errors} parity error(s). Run: npm run schema:generate`);
+    process.exit(1);
+  } else {
+    console.log('\n✅ All schema files are in parity.');
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,48 @@ export interface SourceProvenance {
   createdAt?: string;
 }
 
+/**
+ * Deep Research Foundations metadata for tracking research packet context and evaluation status.
+ * Used by Atlas Chronicle and research delegation workflows.
+ * 
+ * @see https://github.com/avadisabelle/coaia-narrative/issues/39
+ */
+export interface DeepResearchFoundationMetadata {
+  packetRoot?: string;
+  foundationType?: string;
+  parentIssue?: string;
+  baselineIssue?: string;
+  inquiryIssue?: string;
+  protocolIssue?: string;
+  schemaIssue?: string;
+  visualizerIssue?: string;
+  expectedArtifacts?: string[];
+  producedArtifacts?: string[];
+  evaluationStatus?: 'expected' | 'delegated' | 'produced' | 'evaluated';
+  privacyClass?: 'public-safe' | 'private' | 'mixed';
+  publicationStatus?: 'planned' | 'draft' | 'reviewed' | 'published';
+  commitHandles?: string[];
+}
+
+/**
+ * Hermes session lineage metadata tracking conversation branching and handoff state.
+ * Used for reconstructing branch maps and session traceability.
+ * 
+ * @see https://github.com/avadisabelle/coaia-narrative/issues/40
+ */
+export interface HermesSessionLineageMetadata {
+  platform?: string;
+  parentChartId?: string;
+  sourceBeat?: string;
+  originalSessionId?: string;
+  branchSessionId?: string;
+  branchIndex?: number;
+  copiedMessageCount?: number;
+  branchPurpose?: string;
+  relatedIssues?: string[];
+  handoffState?: 'requirements-created' | 'implementation-ready' | 'returned-to-parent';
+}
+
 export interface EntityMetadata {
   dueDate?: string;
   chartId?: string;
@@ -148,6 +190,10 @@ export interface EntityMetadata {
   };
   github?: GithubBridgeMetadata;
   source?: SourceProvenance;
+  /** Deep Research Foundations metadata for research packet tracking and evaluation. */
+  foundation?: DeepResearchFoundationMetadata;
+  /** Hermes session lineage metadata for conversation branching and handoff tracking. */
+  sessionLineage?: HermesSessionLineageMetadata;
   /** @deprecated Use github.issue and github.projectItem instead. */
   sync_target?: LegacyGithubSyncTarget;
   /** @deprecated Use github.issue instead. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,24 @@ export interface HermesSessionLineageMetadata {
   handoffState?: 'requirements-created' | 'implementation-ready' | 'returned-to-parent';
 }
 
+/**
+ * Beat-level lived session context metadata capturing the embodied condition of working sessions.
+ * Records land-based learning, voice/terminal mode, environmental constraints, and continuity context.
+ * 
+ * @see https://github.com/avadisabelle/coaia-narrative/issues/42
+ */
+export interface SessionContextMetadata {
+  mode?: 'voice' | 'terminal' | 'mixed';
+  setting?: 'desk' | 'walking' | 'land-based' | 'transit' | 'unknown';
+  landBasedLearning?: boolean;
+  environmentNotes?: string[];
+  listeningContext?: string;
+  captureQuality?: 'clear' | 'windy' | 'partial';
+  continuationKind?: 'branch' | 'parent-return' | 'follow-up';
+  privateChroniclePath?: string;
+  publicSummaryAllowed?: boolean;
+}
+
 export interface EntityMetadata {
   dueDate?: string;
   chartId?: string;
@@ -194,6 +212,8 @@ export interface EntityMetadata {
   foundation?: DeepResearchFoundationMetadata;
   /** Hermes session lineage metadata for conversation branching and handoff tracking. */
   sessionLineage?: HermesSessionLineageMetadata;
+  /** Beat-level lived session context capturing embodied working conditions and environmental constraints. */
+  sessionContext?: SessionContextMetadata;
   /** @deprecated Use github.issue and github.projectItem instead. */
   sync_target?: LegacyGithubSyncTarget;
   /** @deprecated Use github.issue instead. */

--- a/test-metadata-preservation.js
+++ b/test-metadata-preservation.js
@@ -157,6 +157,38 @@ async function run() {
       }
     },
     {
+      type: 'entity',
+      name: 'chart_preserve_session_context_entity',
+      entityType: 'narrative_beat',
+      observations: ['Session context metadata test entity with lived working conditions'],
+      metadata: {
+        chartId: 'chart_preserve',
+        act: 2,
+        sessionContext: {
+          mode: 'voice',
+          setting: 'walking',
+          landBasedLearning: true,
+          environmentNotes: ['wind', 'outdoor walking', 'land-based learning context'],
+          listeningContext: 'user listened to Atlas Chronicle while walking',
+          captureQuality: 'windy',
+          continuationKind: 'parent-return',
+          privateChroniclePath: '/opt/data/home/.hermes/voice-episodes/atlas-chronicle/2026-05-26-walking-session.m4a',
+          publicSummaryAllowed: true
+        },
+        narrative: {
+          description: 'Walking session with environmental challenges',
+          prose: 'Outdoor session capturing lived learning while listening to Atlas Chronicle.',
+          lessons: ['Environmental context shapes capture quality', 'Land-based learning enriches narrative']
+        },
+        fourDirections: {
+          north_vision: 'embodied learning',
+          east_intention: null,
+          south_emotion: null,
+          west_introspection: 'wind as teacher'
+        }
+      }
+    },
+    {
       type: 'relation',
       from: 'chart_preserve_beat_1',
       to: 'chart_preserve_chart',
@@ -182,6 +214,7 @@ async function run() {
     const beat = findByName(records, 'chart_preserve_beat_1');
     const foundationEntity = findByName(records, 'chart_preserve_foundation_entity');
     const lineageEntity = findByName(records, 'chart_preserve_lineage_entity');
+    const sessionContextEntity = findByName(records, 'chart_preserve_session_context_entity');
     const relation = records.find((record) => record.type === 'relation');
 
     assert(chart.metadata.github.issue === 35, 'chart metadata.github survived');
@@ -217,6 +250,23 @@ async function run() {
     assert(lineageEntity.metadata.sessionLineage.handoffState === 'implementation-ready', 'sessionLineage metadata.handoffState survived');
     assert(lineageEntity.metadata.sessionLineage.relatedIssues.length === 3, 'sessionLineage metadata.relatedIssues array survived');
     assert(lineageEntity.metadata.sessionLineage.relatedIssues[0] === 'avadisabelle/coaia-narrative#39', 'sessionLineage metadata.relatedIssues[0] survived');
+
+    // Asterion issue #42: Session context metadata preservation tests
+    assert(sessionContextEntity.metadata.sessionContext.mode === 'voice', 'sessionContext metadata.mode survived');
+    assert(sessionContextEntity.metadata.sessionContext.setting === 'walking', 'sessionContext metadata.setting survived');
+    assert(sessionContextEntity.metadata.sessionContext.landBasedLearning === true, 'sessionContext metadata.landBasedLearning survived');
+    assert(sessionContextEntity.metadata.sessionContext.environmentNotes.length === 3, 'sessionContext metadata.environmentNotes array survived');
+    assert(sessionContextEntity.metadata.sessionContext.environmentNotes[0] === 'wind', 'sessionContext metadata.environmentNotes[0] survived');
+    assert(sessionContextEntity.metadata.sessionContext.listeningContext === 'user listened to Atlas Chronicle while walking', 'sessionContext metadata.listeningContext survived');
+    assert(sessionContextEntity.metadata.sessionContext.captureQuality === 'windy', 'sessionContext metadata.captureQuality survived');
+    assert(sessionContextEntity.metadata.sessionContext.continuationKind === 'parent-return', 'sessionContext metadata.continuationKind survived');
+    assert(sessionContextEntity.metadata.sessionContext.privateChroniclePath === '/opt/data/home/.hermes/voice-episodes/atlas-chronicle/2026-05-26-walking-session.m4a', 'sessionContext metadata.privateChroniclePath survived');
+    assert(sessionContextEntity.metadata.sessionContext.publicSummaryAllowed === true, 'sessionContext metadata.publicSummaryAllowed survived');
+    
+    // Verify sessionContext coexists with other metadata
+    assert(sessionContextEntity.metadata.narrative.prose === 'Outdoor session capturing lived learning while listening to Atlas Chronicle.', 'sessionContext entity narrative survived');
+    assert(sessionContextEntity.metadata.fourDirections.north_vision === 'embodied learning', 'sessionContext entity fourDirections survived');
+    assert(sessionContextEntity.metadata.fourDirections.west_introspection === 'wind as teacher', 'sessionContext entity fourDirections.west_introspection survived');
 
     if (failed > 0) {
       throw new Error(`Metadata preservation test failed:\n- ${failures.join('\n- ')}`);

--- a/test-metadata-preservation.js
+++ b/test-metadata-preservation.js
@@ -110,6 +110,53 @@ async function run() {
       topLevelExtension: { source: 'legacy-beat' }
     },
     {
+      type: 'entity',
+      name: 'chart_preserve_foundation_entity',
+      entityType: 'artifact',
+      observations: ['Foundation research metadata test entity'],
+      metadata: {
+        chartId: 'chart_preserve',
+        foundation: {
+          packetRoot: 'foundations/atlas-chronicle/',
+          foundationType: 'atlas-chronicle',
+          parentIssue: 'jgwill/coaia-agent#27',
+          baselineIssue: 'jgwill/coaia-agent#31',
+          inquiryIssue: 'jgwill/coaia-agent#29',
+          protocolIssue: 'jgwill/coaia-agent#30',
+          schemaIssue: 'avadisabelle/coaia-narrative#39',
+          visualizerIssue: 'jgwill/coaia-visualizer#24',
+          expectedArtifacts: ['README.md', 'ACADEMIC-FIELD-MAP.md', 'ACADEMIC-COVERAGE-MATRIX.md'],
+          producedArtifacts: ['README.md'],
+          evaluationStatus: 'produced',
+          privacyClass: 'public-safe',
+          publicationStatus: 'draft',
+          commitHandles: ['abc123def456', '789ghi012jkl']
+        }
+      }
+    },
+    {
+      type: 'entity',
+      name: 'chart_preserve_lineage_entity',
+      entityType: 'narrative_beat',
+      observations: ['Session lineage metadata test entity'],
+      metadata: {
+        chartId: 'chart_preserve',
+        act: 1,
+        sessionLineage: {
+          platform: 'telegram',
+          parentChartId: 'chart_1779738656753',
+          sourceBeat: 'chart_1779738656753_beat_1779809139411',
+          originalSessionId: '20260526_150547_aac625',
+          branchSessionId: '20260526_190820_c74f5e',
+          branchIndex: 2,
+          copiedMessageCount: 4,
+          branchPurpose: 'Implement cross-repo metadata requirements for foundation/chart metadata',
+          relatedIssues: ['avadisabelle/coaia-narrative#39', 'avadisabelle/coaia-narrative#40', 'jgwill/coaia-visualizer#24'],
+          handoffState: 'implementation-ready'
+        }
+      }
+    },
+    {
       type: 'relation',
       from: 'chart_preserve_beat_1',
       to: 'chart_preserve_chart',
@@ -133,6 +180,8 @@ async function run() {
     const currentReality = findByName(records, 'chart_preserve_current_reality');
     const action = findByName(records, 'chart_preserve_action_1');
     const beat = findByName(records, 'chart_preserve_beat_1');
+    const foundationEntity = findByName(records, 'chart_preserve_foundation_entity');
+    const lineageEntity = findByName(records, 'chart_preserve_lineage_entity');
     const relation = records.find((record) => record.type === 'relation');
 
     assert(chart.metadata.github.issue === 35, 'chart metadata.github survived');
@@ -148,6 +197,26 @@ async function run() {
     assert(beat.narrative.lessons[0] === 'Unknown fields matter', 'legacy top-level narrative survived');
     assert(beat.topLevelExtension.source === 'legacy-beat', 'narrative beat top-level extension survived');
     assert(relation.metadata.relationExtension.survives === true, 'relation extension metadata survived');
+    
+    // Asterion metadata preservation tests (issues #39 and #40)
+    assert(foundationEntity.metadata.foundation.packetRoot === 'foundations/atlas-chronicle/', 'foundation metadata.packetRoot survived');
+    assert(foundationEntity.metadata.foundation.foundationType === 'atlas-chronicle', 'foundation metadata.foundationType survived');
+    assert(foundationEntity.metadata.foundation.parentIssue === 'jgwill/coaia-agent#27', 'foundation metadata.parentIssue survived');
+    assert(foundationEntity.metadata.foundation.evaluationStatus === 'produced', 'foundation metadata.evaluationStatus survived');
+    assert(foundationEntity.metadata.foundation.privacyClass === 'public-safe', 'foundation metadata.privacyClass survived');
+    assert(foundationEntity.metadata.foundation.publicationStatus === 'draft', 'foundation metadata.publicationStatus survived');
+    assert(foundationEntity.metadata.foundation.expectedArtifacts.length === 3, 'foundation metadata.expectedArtifacts array survived');
+    assert(foundationEntity.metadata.foundation.producedArtifacts[0] === 'README.md', 'foundation metadata.producedArtifacts survived');
+    assert(foundationEntity.metadata.foundation.commitHandles[0] === 'abc123def456', 'foundation metadata.commitHandles survived');
+    
+    assert(lineageEntity.metadata.sessionLineage.platform === 'telegram', 'sessionLineage metadata.platform survived');
+    assert(lineageEntity.metadata.sessionLineage.parentChartId === 'chart_1779738656753', 'sessionLineage metadata.parentChartId survived');
+    assert(lineageEntity.metadata.sessionLineage.sourceBeat === 'chart_1779738656753_beat_1779809139411', 'sessionLineage metadata.sourceBeat survived');
+    assert(lineageEntity.metadata.sessionLineage.branchIndex === 2, 'sessionLineage metadata.branchIndex survived');
+    assert(lineageEntity.metadata.sessionLineage.copiedMessageCount === 4, 'sessionLineage metadata.copiedMessageCount survived');
+    assert(lineageEntity.metadata.sessionLineage.handoffState === 'implementation-ready', 'sessionLineage metadata.handoffState survived');
+    assert(lineageEntity.metadata.sessionLineage.relatedIssues.length === 3, 'sessionLineage metadata.relatedIssues array survived');
+    assert(lineageEntity.metadata.sessionLineage.relatedIssues[0] === 'avadisabelle/coaia-narrative#39', 'sessionLineage metadata.relatedIssues[0] survived');
 
     if (failed > 0) {
       throw new Error(`Metadata preservation test failed:\n- ${failures.join('\n- ')}`);


### PR DESCRIPTION
Implements avadisabelle/coaia-narrative#39 and #40.\n\nTraceability:\n- Parent: jgwill/coaia-agent#27\n- Baseline: jgwill/coaia-agent#31\n- Consumers: jgwill/coaia-visualizer#24 and #25\n\nVerification:\n- npm test: PASS (123 integration checks + 30 metadata preservation checks)\n- npm pack --dry-run: PASS for coaia-narrative@0.13.4\n\nNPM publish:\n- Not published here because npm auth is missing on this machine (npm whoami -> ENEEDAUTH).