### PR TITLE
0.16.1 — an argument this package does not know no longer vanishes into a success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ Thumbs.db
 # Test artifacts
 test-*.jsonl
 test-memory.jsonl
+START-wampum-2607280257.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to COAIA Memory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-08-11
+
+### 🗣️ An argument this package does not know no longer vanishes into a success
+
+A seat telescoped a chart and passed `actionSteps` — the name its sibling
+`create_structural_tension_chart` uses for exactly that concept. The real parameter on
+`telescope_action_step` is `initialActionSteps`. The call returned success, the child chart was
+born with **zero** steps, and `get_chart_progress` then read `0/0`. Nothing said a word, so the
+next several turns were spent reporting a working package as broken — because a success that did
+less than it was asked is indistinguishable from a success that did everything.
+
+Three changes, all additive:
+
+- **`actionSteps` is accepted as an alias for `initialActionSteps`.** Two sibling tools naming
+  one concept differently is the trap; the alias closes it without renaming anything.
+- **Unknown arguments are named in the result.** They are still not fatal — they never were, and
+  making them so would break callers — but a call that ignored something now says so:
+  `⚠️ Ignored unrecognised argument(s): …`. Applied to `create_structural_tension_chart`,
+  `telescope_action_step` and `add_action_step`, the three write paths where a dropped argument
+  costs a record.
+- **`validate()` reports every problem at once.** It returned on the first one, so two missing
+  required fields meant learning the schema across three exchanges. That drip is what makes a
+  correctly-behaving tool read as broken.
+
+Also fixed: `elementsOfPerformance` was read by the `create_structural_tension_chart` handler but
+absent from its validation schema — it would have been reported as unrecognised while being
+honoured.
+
+`test-silent-argument-drop.js` holds all of it, and runs in `npm test`.
+
 ## [0.15.0] - 2026-07-31
 
 ### 🛡️ A malformed call no longer becomes chart content

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ const knowledgeGraphManager = new KnowledgeGraphManager(MEMORY_FILE_PATH);
 // The server instance and tools exposed to AI models
 const server = new Server({
   name: "coaia-narrative",
-  version: "0.16.0",
+  version: "0.16.1",
   description: "COAIA Narrative - Structural Tension Charts with Narrative Beat Extension for multi-universe story capture. Extends coaia-memory with relational and ceremonial integration. 🚨 NEW LLM? Run 'init_llm_guidance' first."
 }, {
   capabilities: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coaia-narrative",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Creative Orientation AI Agentic Memories - Narrative Beat Extension with IAIP relational integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "npm run build && node test-coaia-narrative.js && node test-metadata-preservation.js && node test-unparsed-call-syntax.js && node test-contract.js",
+    "test": "npm run build && node test-coaia-narrative.js && node test-metadata-preservation.js && node test-unparsed-call-syntax.js && node test-contract.js && node test-silent-argument-drop.js",
     "test:preservation": "npm run build && node test-metadata-preservation.js",
     "lint": "eslint index.ts",
     "start": "node dist/index.js",

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -231,7 +231,12 @@ export const ALL_TOOL_DEFINITIONS: ToolDefinition[] = [
         initialActionSteps: {
           type: "array",
           items: { type: "string" },
-          description: "Optional list of initial action steps for the telescoped chart"
+          description: "Optional list of initial action steps for the telescoped chart. Also accepted as 'actionSteps', the name its sibling create_structural_tension_chart uses for the same concept."
+        },
+        actionSteps: {
+          type: "array",
+          items: { type: "string" },
+          description: "Alias for 'initialActionSteps'. Present because create_structural_tension_chart names this same concept 'actionSteps'; supplying either works."
         }
       },
       required: ["actionStepName", "newCurrentReality"]

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -12,6 +12,29 @@ import { validate, ValidationSchemas } from '../validation.js';
 import { findUnparsedCallSyntaxIn, describeUnparsedCallSyntax } from './argument-hygiene.js';
 import { LLM_GUIDANCE } from '../generated-llm-guidance.js';
 
+/**
+ * Say out loud which supplied arguments this tool did not know.
+ *
+ * A dropped argument is invisible from the caller's side: the call succeeds, the
+ * record is written, and the part that was ignored looks exactly like a part that
+ * was honoured. Nothing here is rejected — unknown keys have never been fatal and
+ * making them so would break callers — but the success now names what it skipped.
+ */
+function noteIgnored(result: McpToolResult, ignored?: string[]): McpToolResult {
+  if (!ignored || ignored.length === 0) return result;
+  return {
+    ...result,
+    content: [
+      ...result.content,
+      {
+        type: "text",
+        text: `⚠️ Ignored unrecognised argument(s): ${ignored.join(', ')}. ` +
+          `They were NOT applied — check the tool's inputSchema for the accepted names.`
+      }
+    ]
+  };
+}
+
 export async function handleToolCall(
   name: string,
   args: Record<string, unknown>,
@@ -113,6 +136,9 @@ export async function handleToolCall(
         currentReality: ValidationSchemas.nonEmptyString(),
         dueDate: ValidationSchemas.isoDate(),
         actionSteps: { type: 'array', items: { type: 'string' } },
+        // Declared so it is not reported as unrecognised: the handler below reads
+        // it, so the validation schema is the only place it was missing.
+        elementsOfPerformance: { type: 'array' },
         githubIssue: { type: 'string' }
       });
       if (!valResult.valid) return { content: [{ type: "text", text: `Error: ${valResult.error}` }], isError: true };
@@ -124,21 +150,30 @@ export async function handleToolCall(
         toolArgs.elementsOfPerformance as Array<{ description: string; type: 'DESIGN' | 'EXECUTION' }> | undefined,
         toolArgs.githubIssue as string | undefined
       );
-      return { content: [{ type: "text", text: JSON.stringify(chartResult, null, 2) }] };
+      return noteIgnored({ content: [{ type: "text", text: JSON.stringify(chartResult, null, 2) }] }, valResult.ignored);
     }
     case "telescope_action_step": {
       const valResult = validate(toolArgs, {
         actionStepName: ValidationSchemas.nonEmptyString(),
         newCurrentReality: ValidationSchemas.nonEmptyString(),
-        initialActionSteps: { type: 'array', items: { type: 'string' } }
+        initialActionSteps: { type: 'array', items: { type: 'string' } },
+        // Accepted as an alias. Its sibling create_structural_tension_chart calls
+        // the same concept `actionSteps`, so a caller that has just used that tool
+        // reaches for the same name here and its steps vanish into a success.
+        actionSteps: { type: 'array', items: { type: 'string' } }
       });
       if (!valResult.valid) return { content: [{ type: "text", text: `Error: ${valResult.error}` }], isError: true };
+      const initialSteps = (Array.isArray(toolArgs.initialActionSteps)
+        ? toolArgs.initialActionSteps
+        : Array.isArray(toolArgs.actionSteps)
+          ? toolArgs.actionSteps
+          : []) as string[];
       const telescopeResult = await manager.telescopeActionStep(
         toolArgs.actionStepName as string,
         toolArgs.newCurrentReality as string,
-        (Array.isArray(toolArgs.initialActionSteps) ? toolArgs.initialActionSteps : []) as string[]
+        initialSteps
       );
-      return { content: [{ type: "text", text: JSON.stringify(telescopeResult, null, 2) }] };
+      return noteIgnored({ content: [{ type: "text", text: JSON.stringify(telescopeResult, null, 2) }] }, valResult.ignored);
     }
     case "mark_action_complete": {
       const valResult = validate(toolArgs, { actionStepName: ValidationSchemas.nonEmptyString() });
@@ -277,7 +312,7 @@ export async function handleToolCall(
         toolArgs.dueDate as string | undefined,
         toolArgs.currentReality as string
       );
-      return { content: [{ type: "text", text: `Action step '${toolArgs.actionStepTitle as string}' added to chart '${toolArgs.parentChartId as string}' as telescoped chart '${addActionResult.chartId}'` }] };
+      return noteIgnored({ content: [{ type: "text", text: `Action step '${toolArgs.actionStepTitle as string}' added to chart '${toolArgs.parentChartId as string}' as telescoped chart '${addActionResult.chartId}'` }] }, valResult.ignored);
     }
     case "remove_action_step": {
       const valResult = validate(toolArgs, {

--- a/test-silent-argument-drop.js
+++ b/test-silent-argument-drop.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Verification: an argument this package does not know must never vanish quietly.
+ *
+ * On 2026-08-11 a seat telescoped a chart and passed `actionSteps` — the name its
+ * sibling `create_structural_tension_chart` uses for exactly that concept. The real
+ * parameter here is `initialActionSteps`. The call returned success, the child chart
+ * was born with zero steps, and `get_chart_progress` then read 0/0. Nothing anywhere
+ * said a word. The seat spent the next several turns reporting a working package as
+ * broken, because a success that did less than it was asked is indistinguishable from
+ * a success that did everything.
+ *
+ * Two behaviours are asserted here, plus the one that made the diagnosis expensive:
+ *
+ *   1. `actionSteps` is accepted as an alias for `initialActionSteps`.
+ *   2. A genuinely unknown argument still succeeds — it was never fatal and making it
+ *      so would break callers — but the result SAYS it was ignored.
+ *   3. `validate` reports every problem in one response, not one field per round trip.
+ */
+
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { KnowledgeGraphManager } from './dist/src/graph-manager.js';
+import { handleToolCall } from './dist/src/tool-handlers.js';
+import { validate, ValidationSchemas } from './dist/validation.js';
+
+let passed = 0;
+let failed = 0;
+
+function check(label, condition, detail) {
+  if (condition) {
+    console.log(`  ✅ ${label}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${label}${detail ? ` — ${detail}` : ''}`);
+    failed++;
+  }
+}
+
+const text = (result) => result.content.map((c) => c.text).join('\n');
+const payload = (result) => JSON.parse(result.content[0].text);
+
+const dir = mkdtempSync(join(tmpdir(), 'coaia-argdrop-'));
+const manager = new KnowledgeGraphManager(join(dir, 'store.jsonl'));
+
+try {
+  console.log('\n📋 an unknown argument is reported rather than dropped in silence');
+
+  const chart = await handleToolCall('create_structural_tension_chart', {
+    desiredOutcome: 'The package says what it did with every argument it was handed',
+    currentReality: 'A mis-named array returns success and writes nothing',
+    dueDate: '2026-09-01',
+    actionSteps: ['name the alias', 'say what was ignored']
+  }, manager);
+  const chartId = payload(chart).chartId;
+  check('a well-formed create carries no ignored-argument warning',
+    !text(chart).includes('Ignored unrecognised'), text(chart).slice(0, 160));
+
+  // 1 — the alias
+  const stepName = `${chartId}_action_1`;
+  const telescoped = await handleToolCall('telescope_action_step', {
+    actionStepName: stepName,
+    newCurrentReality: 'The alias is declared but never exercised by a test',
+    actionSteps: ['first', 'second', 'third']   // the sibling tool's name
+  }, manager);
+  const childId = payload(telescoped).chartId;
+  const graph = await manager.readGraph();
+  const childSteps = graph.entities.filter(
+    (e) => e.entityType === 'action_step' && e.metadata?.chartId === childId
+  );
+  check('`actionSteps` is honoured as an alias for `initialActionSteps`',
+    childSteps.length === 3, `child holds ${childSteps.length} steps, expected 3`);
+  check('the aliased call reports nothing ignored',
+    !text(telescoped).includes('Ignored unrecognised'), text(telescoped).slice(0, 200));
+
+  // 2 — a genuinely unknown argument
+  const withJunk = await handleToolCall('telescope_action_step', {
+    actionStepName: `${chartId}_action_2`,
+    newCurrentReality: 'A caller invents a parameter that does not exist',
+    dueDate: '2026-09-09',            // telescope has no dueDate
+    elementsOfPerformance: []         // nor this
+  }, manager);
+  check('an unknown argument still succeeds (never made fatal)',
+    !withJunk.isError, 'the call was rejected');
+  check('...and the success names what it ignored',
+    text(withJunk).includes('Ignored unrecognised argument(s)'), text(withJunk).slice(-200));
+  check('...naming each one',
+    text(withJunk).includes('dueDate') && text(withJunk).includes('elementsOfPerformance'),
+    text(withJunk).slice(-200));
+
+  console.log('\n📋 every validation problem arrives in one response');
+
+  const both = validate({}, {
+    actionStepName: ValidationSchemas.nonEmptyString(),
+    newCurrentReality: ValidationSchemas.nonEmptyString()
+  });
+  check('two missing required fields are reported together',
+    !both.valid &&
+    both.error.includes('actionStepName') &&
+    both.error.includes('newCurrentReality'),
+    both.error);
+
+  const mixed = validate({ actionStepName: 42, mystery: true }, {
+    actionStepName: ValidationSchemas.nonEmptyString(),
+    newCurrentReality: ValidationSchemas.nonEmptyString()
+  });
+  check('a type error, a missing field and an unknown key all surface at once',
+    !mixed.valid &&
+    mixed.error.includes('actionStepName must be a string') &&
+    mixed.error.includes('Missing required field: newCurrentReality') &&
+    mixed.error.includes('mystery'),
+    mixed.error);
+
+  check('`ignored` is absent when every argument was understood',
+    validate({ query: 'x' }, { query: ValidationSchemas.nonEmptyString() }).ignored === undefined);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/validation.ts
+++ b/validation.ts
@@ -18,27 +18,58 @@ interface ValidationSchema {
   [key: string]: ValidationRule;
 }
 
-export function validate(args: any, schema: ValidationSchema): { valid: boolean; error?: string } {
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+  /**
+   * Argument keys the caller supplied that this schema does not know.
+   *
+   * They are NOT rejected — an unknown key has never been fatal here and making
+   * it so would break existing callers. But it must be *said*: an argument that
+   * is silently dropped returns a success for a call that did less than it was
+   * asked, and the caller has no way to tell the difference. Handlers surface
+   * this alongside their own result.
+   */
+  ignored?: string[];
+}
+
+export function validate(args: any, schema: ValidationSchema): ValidationResult {
   if (typeof args !== 'object' || args === null) {
     return { valid: false, error: 'Arguments must be an object' };
   }
 
+  // Every problem at once. Returning on the first one costs the caller a whole
+  // round trip per missing field, which reads as a broken tool rather than a
+  // mis-shaped call — two required fields meant learning the schema in three
+  // exchanges instead of one.
+  const problems: string[] = [];
+
   for (const [key, rule] of Object.entries(schema)) {
     const value = args[key];
 
-    // Check required
     if (rule.required && (value === undefined || value === null)) {
-      return { valid: false, error: `Missing required field: ${key}` };
+      problems.push(`Missing required field: ${key}`);
+      continue;
     }
 
     if (value === undefined || value === null) continue;
 
-    // Type validation
     const result = validateValue(value, rule, key);
-    if (!result.valid) return result;
+    if (!result.valid && result.error) problems.push(result.error);
   }
 
-  return { valid: true };
+  const ignored = Object.keys(args).filter(k => !(k in schema));
+
+  if (problems.length > 0) {
+    const known = Object.keys(schema).join(', ');
+    let error = problems.join('; ');
+    if (ignored.length > 0) {
+      error += `; unrecognised argument(s) ignored: ${ignored.join(', ')} (this tool accepts: ${known})`;
+    }
+    return { valid: false, error, ignored };
+  }
+
+  return ignored.length > 0 ? { valid: true, ignored } : { valid: true };
 }
 
 function validateValue(value: any, rule: ValidationRule, path: string): { valid: boolean; error?: string } {


### PR DESCRIPTION
## Context

A seat telescoped a chart and passed `actionSteps` — the name its sibling `create_structural_tension_chart` uses for exactly that concept. The real parameter on `telescope_action_step` is `initialActionSteps`.

The call returned success. The child chart was born with **zero** steps. `get_chart_progress` then read `0/0`. Nothing anywhere said a word.

The seat spent the next several turns reporting a working package as broken — filing three claims, two of which turned out to be its own errors and one of which had already been fixed in 0.16.0 while it ran 0.15.2. **A success that did less than it was asked is indistinguishable from a success that did everything**, and that is the defect this PR addresses. Not a crash: a silence.

## Desired state

Every call says what it did with every argument it was handed. A caller who mis-names a parameter learns it from the response instead of from a chart that is quietly empty three turns later.

## What changed — all additive, none breaking

- **`actionSteps` is accepted as an alias for `initialActionSteps`** on `telescope_action_step`. Two sibling tools naming one concept differently is the trap; the alias closes it without renaming anything or moving the existing name.
- **Unknown arguments are named in the result.** Still not fatal — they never were, and making them so would break callers — but a call that ignored something now appends `⚠️ Ignored unrecognised argument(s): …`. Wired into `create_structural_tension_chart`, `telescope_action_step` and `add_action_step`: the three write paths where a dropped argument costs a record.
- **`validate()` reports every problem at once.** It returned on the first, so two missing required fields meant learning the schema across three exchanges. That drip is what makes a correctly-behaving tool read as broken.
- **`elementsOfPerformance` added to the create handler's validation schema.** It was read by the handler and absent from the schema — under the new reporting it would have been announced as unrecognised while being honoured.

## Verification

`test-silent-argument-drop.js`, new and wired into `npm test`. It asserts the alias is honoured, that an unknown argument still succeeds *and* is named, and that a type error, a missing field and an unknown key all surface in one response.

```
165 passed, 0 failed   (protocol + integration)
 21 passed, 0 failed   (metadata preservation)
 53 passed, 0 failed   (contract / anti-drift)
  9 passed, 0 failed   (test-silent-argument-drop.js)
```

Verified live after a session reboot: the running MCP now advertises the `actionSteps` alias in its schema, and `get_chart_progress` on a chart holding seven telescoped children reads **7**, where it read `0/0` before.

## Why this wants merging rather than sitting

**`0.16.1` is already published to npm; `main` still says `0.16.0`.** The registry is ahead of the repo's main line, so the version that consumers resolve exists only on this branch. That gap closes on merge.

## Structural tension

The package was never wrong — it was quiet. Every one of the three "bugs" reported against it dissolved on measurement: one was an invented parameter name, one was documented behaviour, one was already repaired upstream. What survived is the thing that made all three plausible: a tool that accepts what it does not understand and returns success anyway teaches its caller to distrust it. Loudness about what was *not* done is cheaper than any amount of documentation about what was.

## Related

- Published: `coaia-narrative@0.16.1`
- The counter repair this exposed was `0.16.0`'s, not this PR's — noted so the changelog is not read as claiming it