### PR TITLE
0.16.2 — a --memory-path carrying an unexpanded shell variable is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to COAIA Memory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-08-11
+
+### 🛑 A `--memory-path` carrying an unexpanded shell variable is refused
+
+A seat booted with `MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH` unset. Its `.mcp.json` handed this
+server the placeholder verbatim, and the server started happily and wrote a live structural tension
+chart into a file literally **named** `${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}` in whatever
+directory it was launched from. Nothing failed. The charts were simply somewhere nobody would look,
+and it took a second seat auditing the boot to find them.
+
+Fatal rather than a warning, because of the sibling case: a variable set to a path that does **not
+exist** starts this server **clean and empty**, and the seat reports its whole store lost. A store is
+the one input where "start anyway" is never the kind answer.
+
+`$` stays legal in a filename — only a literal `${` is refused, because a caller writing that is
+quoting a shell they expected to have run. `test-unexpanded-memory-path.js` holds it, including the
+assertion that matters most: **no literally-named file is created**.
+
+Same family as 0.16.1 — a surface that answers without saying what it did.
+
 ## [0.16.1] - 2026-08-11
 
 ### 🗣️ An argument this package does not know no longer vanishes into a success

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,38 @@ if (argv.help || argv.h) {
 
 let memoryPath = argv['memory-path'];
 
+/**
+ * Refuse a path that still carries an unexpanded shell variable.
+ *
+ * Paid for 2026-08-11. A seat booted with `MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH`
+ * unset, so its `.mcp.json` handed this process the placeholder verbatim. The server
+ * started happily and wrote a live structural tension chart into a file literally
+ * NAMED `${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}` in whatever directory it
+ * happened to be launched from. Nothing failed. The seat's charts were simply
+ * somewhere nobody would ever look, and it took another seat auditing the boot to
+ * find them.
+ *
+ * The sibling failure is worse and is the reason this is fatal rather than a warning:
+ * had the variable been set to a path that does not exist, this server would have
+ * started CLEAN and EMPTY, and the seat would have reported its whole store lost.
+ * A store is the one input where "start anyway" is never the kind answer.
+ *
+ * `${` cannot appear in a legitimate path here: `$` is legal in a filename, but a
+ * caller writing `${...}` is quoting a shell they expected to have run.
+ */
+if (typeof memoryPath === 'string' && memoryPath.includes('${')) {
+  console.error(
+    `[coaia-narrative] Refusing to start: --memory-path contains an unexpanded ` +
+    `shell variable.\n` +
+    `  got: ${memoryPath}\n` +
+    `  The variable was not set in the environment that launched this process, so ` +
+    `this would create a file with that literal name and write your charts into it ` +
+    `where nothing will find them.\n` +
+    `  Fix the environment (or pass a real path) and start again — no store was touched.`
+  );
+  process.exit(1);
+}
+
 // If a custom path is provided, ensure it's absolute
 if (memoryPath && !isAbsolute(memoryPath)) {
   memoryPath = path.resolve(process.cwd(), memoryPath);
@@ -53,7 +85,7 @@ const knowledgeGraphManager = new KnowledgeGraphManager(MEMORY_FILE_PATH);
 // The server instance and tools exposed to AI models
 const server = new Server({
   name: "coaia-narrative",
-  version: "0.16.1",
+  version: "0.16.2",
   description: "COAIA Narrative - Structural Tension Charts with Narrative Beat Extension for multi-universe story capture. Extends coaia-memory with relational and ceremonial integration. 🚨 NEW LLM? Run 'init_llm_guidance' first."
 }, {
   capabilities: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coaia-narrative",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Creative Orientation AI Agentic Memories - Narrative Beat Extension with IAIP relational integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "npm run build && node test-coaia-narrative.js && node test-metadata-preservation.js && node test-unparsed-call-syntax.js && node test-contract.js && node test-silent-argument-drop.js",
+    "test": "npm run build && node test-coaia-narrative.js && node test-metadata-preservation.js && node test-unparsed-call-syntax.js && node test-contract.js && node test-silent-argument-drop.js && node test-unexpanded-memory-path.js",
     "test:preservation": "npm run build && node test-metadata-preservation.js",
     "lint": "eslint index.ts",
     "start": "node dist/index.js",

--- a/test-unexpanded-memory-path.js
+++ b/test-unexpanded-memory-path.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Verification: a --memory-path carrying an unexpanded shell variable is refused.
+ *
+ * On 2026-08-11 a seat booted with MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH unset.
+ * Its .mcp.json handed this server the placeholder verbatim. The server started
+ * happily and wrote a live structural tension chart into a file literally NAMED
+ * `${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}`. Nothing failed; the charts were
+ * simply somewhere nobody would look, and another seat auditing the boot found them.
+ *
+ * Fatal rather than a warning, because of the sibling case: a variable set to a path
+ * that does not exist starts the server CLEAN AND EMPTY, and the seat reports its
+ * whole store lost. A store is the one input where "start anyway" is never kind.
+ */
+
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, readdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const ENTRY = resolve(fileURLToPath(new URL('.', import.meta.url)), 'dist/index.js');
+
+let passed = 0;
+let failed = 0;
+
+function check(label, condition, detail) {
+  if (condition) {
+    console.log(`  ✅ ${label}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${label}${detail ? ` — ${detail}` : ''}`);
+    failed++;
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'coaia-envvar-'));
+
+function start(memoryPath) {
+  // The server speaks MCP on stdio and would block; an empty stdin closes it.
+  return spawnSync(process.execPath, [ENTRY, '--memory-path', memoryPath], {
+    cwd: dir,
+    input: '',
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...process.env, COAIA_TOOLS: 'STC_TOOLS' },
+  });
+}
+
+try {
+  console.log('\n📋 an unexpanded shell variable in --memory-path is fatal');
+
+  const r = start('${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}');
+  check('exits non-zero', r.status === 1, `status=${r.status}`);
+  check('says what it refused and why',
+    /unexpanded shell variable/i.test(r.stderr || ''), (r.stderr || '').slice(0, 200));
+  check('echoes the offending value back',
+    (r.stderr || '').includes('MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH'),
+    (r.stderr || '').slice(0, 200));
+  check('promises nothing was touched',
+    /no store was touched/i.test(r.stderr || ''), (r.stderr || '').slice(0, 200));
+
+  const stray = readdirSync(dir).filter((f) => f.includes('${'));
+  check('creates NO literally-named file — the whole point',
+    stray.length === 0, `found: ${stray.join(', ')}`);
+
+  console.log('\n📋 a bare $ in a filename is still legal, and a real path still starts');
+
+  const dollar = join(dir, 'my$charts.jsonl');
+  writeFileSync(dollar, '');
+  const ok = start(dollar);
+  check('a path containing $ but no ${ is not refused',
+    !/unexpanded shell variable/i.test(ok.stderr || ''), (ok.stderr || '').slice(0, 160));
+
+  const rel = start('charts.jsonl');
+  check('a relative path is not refused',
+    !/unexpanded shell variable/i.test(rel.stderr || ''), (rel.stderr || '').slice(0, 160));
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## The failure

A seat booted with `MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH` unset. Its `.mcp.json` handed this server the placeholder verbatim. The server started happily and wrote a **live structural tension chart** into a file literally named:

```
${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}
```

Nothing failed. Twenty-one records, eight entities, in a file nobody would ever look for — found only because a second seat audited the boot. The chart it swallowed was the one chartering *the seat knowing where it lives*.

## Why fatal, not a warning

The sibling case is worse. A variable set to a path that **does not exist** starts this server **clean and empty** — and the seat reports its entire store lost. A store is the one input where "start anyway" is never the kind answer.

## The rule

`$` stays legal in a filename. Only a literal `${` is refused, because a caller writing that is quoting a shell they expected to have run.

```
[coaia-narrative] Refusing to start: --memory-path contains an unexpanded shell variable.
  got: ${MIADI_MINO_STCBOT_TRIAGE_CHART_MEMORY_PATH}
  ...
  Fix the environment (or pass a real path) and start again — no store was touched.
```

## Verification

`test-unexpanded-memory-path.js`, wired into `npm test`. Seven assertions, and the one that matters most is that **no literally-named file is created**. Also asserted: a path containing `$` but no `${` still starts, and a relative path still starts.

```
165 passed, 0 failed   (protocol + integration)
 21 passed, 0 failed   (metadata preservation)
 53 passed, 0 failed   (contract / anti-drift)
  9 passed, 0 failed   (silent argument drop, 0.16.1)
  7 passed, 0 failed   (unexpanded memory path, this PR)
```

## Structural tension

Same family as `0.16.1` — **a surface that answers without saying what it did.** That release taught the tool to name arguments it ignored. This one teaches it to refuse an input it cannot honestly honour. Both are the same lesson from opposite ends: silence is the defect, not the error.

**The strongest argument against:** `${` is a heuristic, not a contract. A pathological but legal filename containing `${` now cannot be used, and the real generalisation — *validate that the store's parent directory exists and warn when a named store is being created for the first time* — would catch this case and the empty-store case together. This ships the narrow guard because the wide one changes startup semantics for every existing caller.

## Related

- Chart recovered by hand at `miadisabelle/workspace@e2c554b` — the orphan is archived, not deleted.